### PR TITLE
Initial implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 const { parse } = require("./lib/parser");
+const { rules } = require("./lib/rules");
+const { configs } = require("./lib/configs");
 
 module.exports = {
-  parseForESLint: parse
+  parseForESLint: parse,
+  rules,
+  configs
 };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+const { parse } = require("./lib/parser");
+
+module.exports = {
+  parseForESLint: parse
+};

--- a/lib/configs.js
+++ b/lib/configs.js
@@ -1,0 +1,25 @@
+const eslint_recommended_overrides = {
+  "no-unused-labels": "off",
+  "@jarrodldavis/svelte/no-unused-labels": "error"
+};
+
+const eslint_all_overrides = {
+  ...eslint_recommended_overrides,
+  "no-labels": "off",
+  "@jarrodldavis/svelte/no-labels": "error"
+};
+
+const configs = {
+  "eslint:recommended": {
+    extends: ["eslint:recommended"],
+    plugins: ["@jarrodldavis/svelte"],
+    rules: eslint_recommended_overrides
+  },
+  "eslint:all": {
+    extends: ["eslint:all"],
+    plugins: ["@jarrodldavis/svelte"],
+    rules: eslint_all_overrides
+  }
+};
+
+module.exports = { configs };

--- a/lib/configs.js
+++ b/lib/configs.js
@@ -7,7 +7,7 @@ const eslint_all_overrides = {
   ...eslint_recommended_overrides,
   "no-labels": "off",
   "@jarrodldavis/svelte/no-labels": "error",
-  "indent": "off",
+  indent: "off",
   "@jarrodldavis/svelte/indent": "error"
 };
 

--- a/lib/configs.js
+++ b/lib/configs.js
@@ -6,7 +6,9 @@ const eslint_recommended_overrides = {
 const eslint_all_overrides = {
   ...eslint_recommended_overrides,
   "no-labels": "off",
-  "@jarrodldavis/svelte/no-labels": "error"
+  "@jarrodldavis/svelte/no-labels": "error",
+  "indent": "off",
+  "@jarrodldavis/svelte/indent": "error"
 };
 
 const configs = {

--- a/lib/configs.js
+++ b/lib/configs.js
@@ -14,11 +14,13 @@ const eslint_all_overrides = {
 const configs = {
   "eslint:recommended": {
     extends: ["eslint:recommended"],
+    parser: "@jarrodldavis/eslint-plugin-svelte",
     plugins: ["@jarrodldavis/svelte"],
     rules: eslint_recommended_overrides
   },
   "eslint:all": {
     extends: ["eslint:all"],
+    parser: "@jarrodldavis/eslint-plugin-svelte",
     plugins: ["@jarrodldavis/svelte"],
     rules: eslint_all_overrides
   }

--- a/lib/parser/convert-ast.js
+++ b/lib/parser/convert-ast.js
@@ -1,5 +1,5 @@
 const { traverse } = require("estraverse");
-const { parse, tokenize } = require("espree");
+const { parse } = require("espree");
 const { KEYS, EXPRESSION_NODES } = require("./keys");
 const { create_tag_tokens, create_text_tokens } = require("./tokenizer");
 
@@ -35,15 +35,46 @@ function convert(ast, code, options) {
     return positionable;
   }
 
+  // reparse expressions to ensure correct `range` values
+  // (especially for template strings)
   function tokenize_template_expression(node) {
     const { start, end } = node;
     const slice = code.slice(start, end);
 
     const offset_position = offset.bind(null, start);
 
-    const node_tokens = tokenize(slice, options);
-    program.tokens.push(...node_tokens.map(offset_position));
-    program.comments.push(...node_tokens.comments.map(offset_position));
+    const { tokens, comments, body } = parse(slice, options);
+
+    if (body.length === 0) {
+      throw new Error(`Failed to parse template expression '${slice}'`);
+    }
+
+    if (body.length > 2) {
+      throw new Error(
+        `Unexpected multiline parse result for template expression '${slice}'`
+      );
+    }
+
+    const reparsed_node = body[0];
+
+    if (reparsed_node.type !== "ExpressionStatement") {
+      throw new Error(
+        `Unexpected non-expression parse result for template expression '${slice}'.`
+      );
+    }
+
+    if (reparsed_node.expression.type !== node.type) {
+      throw new Error(
+        `Parse result mismatch for template expression '${slice}': expected '${
+          node.type
+        }', got '${reparsed_node.expression.type}`
+      );
+    }
+
+    Object.assign(node, reparsed_node.expression);
+    traverse(node, { enter: offset_position });
+    program.tokens.push(...tokens.map(offset_position));
+    program.comments.push(...comments.map(offset_position));
   }
 
   function set_loc(node) {
@@ -54,8 +85,8 @@ function convert(ast, code, options) {
       return;
     }
 
-    node.range = [start, end];
-    node.loc = get_loc(lines, start, end);
+    node.range = node.range || [start, end];
+    node.loc = node.loc || get_loc(lines, start, end);
     return node;
   }
 

--- a/lib/parser/convert-ast.js
+++ b/lib/parser/convert-ast.js
@@ -56,8 +56,18 @@ function convert(ast, code, options) {
     node.range = [start, end];
     node.loc = get_loc(lines, start, end);
 
-    if (EXPRESSION_NODES.indexOf(node.type) > -1) {
+    if (EXPRESSION_NODES.indexOf(node.type) > -1 && node.expression) {
       tokenize_template_expression(node.expression);
+    }
+
+    if (node.type === "InlineComponent" && /[A-Z]/.test(node.name[0])) {
+      node.identifier = {
+        type: "Identifier",
+        name: node.name,
+        start: node.start + 1,
+        end: node.start + 1 + node.name.length
+      };
+      tokenize_template_expression(node.identifier);
     }
 
     if (node.type === "EachBlock") {

--- a/lib/parser/convert-ast.js
+++ b/lib/parser/convert-ast.js
@@ -1,7 +1,7 @@
 const { traverse } = require("estraverse");
 const { parse, tokenize } = require("espree");
 const { KEYS, EXPRESSION_NODES } = require("./keys");
-const { add_tag_tokens, add_mustache_tokens } = require("./tokenizer");
+const { create_tag_tokens, create_text_tokens } = require("./tokenizer");
 
 const offset_marker = Symbol("eslint-plugin-svelte offset traversal marker");
 
@@ -85,8 +85,8 @@ function convert(ast, code, options) {
   function enter(node) {
     set_loc(node);
     tokenize_expression_children(node);
-    program.tokens.push(...add_tag_tokens(node).map(set_loc));
-    program.tokens.push(...add_mustache_tokens(node, code).map(set_loc));
+    program.tokens.push(...create_tag_tokens(node, code).map(set_loc));
+    program.tokens.push(...create_text_tokens(node).map(set_loc));
   }
 
   traverse(program, { enter, keys: KEYS });

--- a/lib/parser/convert-ast.js
+++ b/lib/parser/convert-ast.js
@@ -15,21 +15,34 @@ function convert(ast, code, options) {
   program.tokens = [];
   program.comments = [];
 
+  function offset(amount, positionable) {
+    if (
+      typeof positionable.start !== "number" ||
+      typeof positionable.end !== "number" ||
+      !Array.isArray(positionable.range) ||
+      positionable[offset_marker] === true
+    ) {
+      return;
+    }
+
+    positionable.start += amount;
+    positionable.end += amount;
+    positionable.range = positionable.range.map(index => index + amount);
+    positionable.loc = get_loc(lines, positionable.start, positionable.end);
+    positionable[offset_marker] = true;
+
+    return positionable;
+  }
+
   function tokenize_template_expression(node) {
     const { start, end } = node;
     const slice = code.slice(start, end);
 
-    function offset(token) {
-      token.start += start;
-      token.end += start;
-      token.range = token.range.map(index => index + start);
-      token.loc = get_loc(lines, token.start, token.end);
-      return token;
-    }
+    const offset_position = offset.bind(null, start);
 
     const node_tokens = tokenize(slice, options);
-    program.tokens.push(...node_tokens.map(offset));
-    program.comments.push(...node_tokens.comments.map(offset));
+    program.tokens.push(...node_tokens.map(offset_position));
+    program.comments.push(...node_tokens.comments.map(offset_position));
   }
 
   function set_loc(node) {
@@ -69,29 +82,7 @@ function convert(ast, code, options) {
     const content_slice = code.slice(content_start, content_end);
     const js_ast = parse(content_slice, options);
 
-    function offset_position(positionable) {
-      if (
-        typeof positionable.start !== "number" ||
-        typeof positionable.end !== "number" ||
-        !Array.isArray(positionable.range)
-      ) {
-        return;
-      }
-
-      if (positionable[offset_marker]) {
-        return;
-      }
-
-      positionable.start += content_start;
-      positionable.end += content_start;
-      positionable.range = positionable.range.map(
-        index => index + content_start
-      );
-      positionable.loc = get_loc(lines, positionable.start, positionable.end);
-      positionable[offset_marker] = true;
-
-      return positionable;
-    }
+    const offset_position = offset.bind(null, content_start);
 
     traverse(js_ast, { enter: offset_position });
 

--- a/lib/parser/convert-ast.js
+++ b/lib/parser/convert-ast.js
@@ -1,6 +1,7 @@
 const { traverse } = require("estraverse");
 const { parse, tokenize } = require("espree");
 const { KEYS, EXPRESSION_NODES } = require("./keys");
+const { add_tag_tokens, add_mustache_tokens } = require("./tokenizer");
 
 const offset_marker = Symbol("eslint-plugin-svelte offset traversal marker");
 
@@ -55,6 +56,7 @@ function convert(ast, code, options) {
 
     node.range = [start, end];
     node.loc = get_loc(lines, start, end);
+    return node;
   }
 
   function tokenize_expression_children(node) {
@@ -83,6 +85,8 @@ function convert(ast, code, options) {
   function enter(node) {
     set_loc(node);
     tokenize_expression_children(node);
+    program.tokens.push(...add_tag_tokens(node).map(set_loc));
+    program.tokens.push(...add_mustache_tokens(node, code).map(set_loc));
   }
 
   traverse(program, { enter, keys: KEYS });
@@ -164,7 +168,7 @@ function get_loc(lines, start, end) {
   }
 
   const start_line = lines.findIndex(
-    line => line.start <= start && line.end >= start
+    line => line.start <= start && line.end > start
   );
   if (start_line === -1) {
     throw new Error(

--- a/lib/parser/convert-ast.js
+++ b/lib/parser/convert-ast.js
@@ -103,7 +103,7 @@ function convert(ast, code, options) {
     traverse(js_root, { enter, keys: { ScriptElement: ["content"] } });
 
     // reparse js code using espree to get correct `node.range` values
-    // (especially for template elements)
+    // (especially for template string elements)
     const content_start = js_root.content.start;
     const content_end = js_root.content.end;
     const content_slice = code.slice(content_start, content_end);

--- a/lib/parser/convert-ast.js
+++ b/lib/parser/convert-ast.js
@@ -1,0 +1,184 @@
+const { traverse } = require("estraverse");
+const { parse, tokenize } = require("espree");
+const { KEYS, EXPRESSION_NODES } = require("./keys");
+
+const offset_marker = Symbol("eslint-plugin-svelte offset traversal marker");
+
+function convert(ast, code, options) {
+  const { html: program, css, module: js_module, instance: js_instance } = ast;
+  const lines = get_lines(code);
+
+  program.type = "Program";
+  program.sourceType = "module";
+  program.body = program.children;
+  delete program.children;
+  program.tokens = [];
+  program.comments = [];
+
+  function tokenize_template_expression(node) {
+    const { start, end } = node;
+    const slice = code.slice(start, end);
+
+    function offset(token) {
+      token.start += start;
+      token.end += start;
+      token.range = token.range.map(index => index + start);
+      token.loc = get_loc(lines, token.start, token.end);
+      return token;
+    }
+
+    const node_tokens = tokenize(slice, options);
+    program.tokens.push(...node_tokens.map(offset));
+    program.comments.push(...node_tokens.comments.map(offset));
+  }
+
+  function set_loc(node) {
+    const { start, end } = node;
+
+    if (typeof start !== "number" || typeof end !== "number") {
+      // TODO: delete node?
+      return;
+    }
+
+    node.range = [start, end];
+    node.loc = get_loc(lines, start, end);
+
+    // TODO: await and each blocks
+    if (EXPRESSION_NODES.indexOf(node.type) > -1) {
+      tokenize_template_expression(node.expression, options);
+    }
+  }
+
+  traverse(program, { enter: set_loc, keys: KEYS });
+
+  if (css) {
+    css.type = "StyleElement";
+    traverse(css, { enter: set_loc, fallback: "iteration" });
+  }
+
+  function convert_js(js_root) {
+    // traverse original js tree in case rules operating on template use it
+    // i.e. marking the <script> tag with a report (instead of just the js code)
+    js_root.type = "ScriptElement";
+    traverse(js_root, { enter: set_loc, keys: { ScriptElement: ["content"] } });
+
+    // reparse js code using espree to get correct `node.range` values
+    // (especially for template elements)
+    const content_start = js_root.content.start;
+    const content_end = js_root.content.end;
+    const content_slice = code.slice(content_start, content_end);
+    const js_ast = parse(content_slice, options);
+
+    function offset_position(positionable) {
+      if (
+        typeof positionable.start !== "number" ||
+        typeof positionable.end !== "number" ||
+        !Array.isArray(positionable.range)
+      ) {
+        return;
+      }
+
+      if (positionable[offset_marker]) {
+        return;
+      }
+
+      positionable.start += content_start;
+      positionable.end += content_start;
+      positionable.range = positionable.range.map(
+        index => index + content_start
+      );
+      positionable.loc = get_loc(lines, positionable.start, positionable.end);
+      positionable[offset_marker] = true;
+
+      return positionable;
+    }
+
+    traverse(js_ast, { enter: offset_position });
+
+    // push espree info into main tree
+    program.body.push(...js_ast.body);
+    program.tokens.push(...js_ast.tokens.map(offset_position));
+    program.comments.push(...js_ast.comments.map(offset_position));
+  }
+
+  if (js_module) {
+    convert_js(js_module);
+  }
+
+  if (js_instance) {
+    convert_js(js_instance);
+  }
+
+  program.body.sort((node1, node2) => node1.start - node2.start);
+  program.end = Math.max(
+    program.end,
+    program.body[program.body.length - 1].end
+  );
+  program.tokens.sort((token1, token2) => token1.range[0] - token2.range[0]);
+  program.comments.sort(
+    (comment1, comment2) => comment1.range[0] - comment2.range[0]
+  );
+
+  return { program, css, js_instance, js_module };
+}
+
+function get_lines(code) {
+  const split = code.split(/(\r?\n)/);
+
+  let code_index = 0;
+  const lines = [];
+  for (line_index = 0; line_index < split.length; line_index += 2) {
+    const text = split[line_index];
+    const eol = split[line_index + 1] || "";
+
+    const length = text.length + eol.length;
+    lines.push({ text, eol, start: code_index, end: code_index + length });
+    code_index += length;
+  }
+  return lines;
+}
+
+function get_loc(lines, start, end) {
+  if (!Array.isArray(lines)) {
+    throw new TypeError(`Expected lines to be an array, got '${lines}'`);
+  }
+  if (!Number.isInteger(start)) {
+    throw new TypeError(`Expected start to be an integer, got '${start}'`);
+  }
+  if (!Number.isInteger(end)) {
+    throw new TypeError(`Expected end to be an integer, got '${end}'`);
+  }
+
+  const start_line = lines.findIndex(
+    line => line.start <= start && line.end >= start
+  );
+  if (start_line === -1) {
+    throw new Error(
+      `Could not find line for start character position ${start}`
+    );
+  }
+
+  const start_column = start - lines[start_line].start;
+
+  const end_line = lines.findIndex(
+    line => line.start <= end && line.end >= end
+  );
+  if (end_line === -1) {
+    throw new Error(`Could not find line for end character position ${end}`);
+  }
+
+  const end_column = end - lines[end_line].start;
+
+  return {
+    start: {
+      line: start_line + 1, // 1-indexed
+      column: start_column
+    },
+    end: {
+      line: end_line + 1, // 1-indexed
+      column: end_column
+    }
+  };
+}
+
+module.exports = { convert };

--- a/lib/parser/convert-ast.js
+++ b/lib/parser/convert-ast.js
@@ -55,7 +55,9 @@ function convert(ast, code, options) {
 
     node.range = [start, end];
     node.loc = get_loc(lines, start, end);
+  }
 
+  function tokenize_expression_children(node) {
     if (EXPRESSION_NODES.indexOf(node.type) > -1 && node.expression) {
       tokenize_template_expression(node.expression);
     }
@@ -78,18 +80,23 @@ function convert(ast, code, options) {
     }
   }
 
-  traverse(program, { enter: set_loc, keys: KEYS });
+  function enter(node) {
+    set_loc(node);
+    tokenize_expression_children(node);
+  }
+
+  traverse(program, { enter, keys: KEYS });
 
   if (css) {
     css.type = "StyleElement";
-    traverse(css, { enter: set_loc, fallback: "iteration" });
+    traverse(css, { enter, fallback: "iteration" });
   }
 
   function convert_js(js_root) {
     // traverse original js tree in case rules operating on template use it
     // i.e. marking the <script> tag with a report (instead of just the js code)
     js_root.type = "ScriptElement";
-    traverse(js_root, { enter: set_loc, keys: { ScriptElement: ["content"] } });
+    traverse(js_root, { enter, keys: { ScriptElement: ["content"] } });
 
     // reparse js code using espree to get correct `node.range` values
     // (especially for template elements)

--- a/lib/parser/convert-ast.js
+++ b/lib/parser/convert-ast.js
@@ -56,9 +56,15 @@ function convert(ast, code, options) {
     node.range = [start, end];
     node.loc = get_loc(lines, start, end);
 
-    // TODO: await and each blocks
     if (EXPRESSION_NODES.indexOf(node.type) > -1) {
-      tokenize_template_expression(node.expression, options);
+      tokenize_template_expression(node.expression);
+    }
+
+    if (node.type === "EachBlock") {
+      tokenize_template_expression(node.context);
+      if (node.key) {
+        tokenize_template_expression(node.key);
+      }
     }
   }
 

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -1,0 +1,44 @@
+const { compile } = require("svelte/compiler");
+
+const { convert } = require("./convert-ast");
+const { analyze } = require("./referencer");
+const { KEYS } = require("./keys");
+
+function parse(code, options) {
+  let result;
+  try {
+    result = compile(code, { generate: false });
+  } catch (error) {
+    if (!error.start) {
+      throw error;
+    }
+
+    const { line, column, character } = error.start;
+    error.lineNumber = line;
+    error.column = column;
+    error.index = character;
+    throw error;
+  }
+
+  const { program, css, js_instance, js_module } = convert(
+    result.ast,
+    code,
+    options
+  );
+  const scopeManager = analyze(program, options);
+
+  return {
+    ast: program,
+    services: {
+      warnings: result.warnings,
+      vars: result.vars,
+      css,
+      js_instance,
+      js_module
+    },
+    visitorKeys: KEYS,
+    scopeManager
+  };
+}
+
+module.exports = { parse };

--- a/lib/parser/keys.js
+++ b/lib/parser/keys.js
@@ -1,11 +1,12 @@
-const evk = require("eslint-visitor-keys");
+const base_keys = require("eslint-visitor-keys");
 
-const ELEMENT_KEYS = ["children", "attributes"];
-const EXPRESSION_KEY = ["expression"];
+const EXPRESSION_KEY = "expression";
+const CHILDREN_KEY = "children";
+const ELEMENT_KEYS = [CHILDREN_KEY, "attributes"];
 
-const KEYS = evk.unionWith({
+const KEYS = base_keys.unionWith({
   // fragment: root
-  Fragment: ["children"],
+  Fragment: [CHILDREN_KEY],
 
   // tag: comment
   Comment: [],
@@ -17,7 +18,7 @@ const KEYS = evk.unionWith({
   Body: ELEMENT_KEYS,
 
   // tag: component references, including <svelte:component /> and <svelte:self />
-  InlineComponent: [...ELEMENT_KEYS, ...EXPRESSION_KEY, "identifier"],
+  InlineComponent: [...ELEMENT_KEYS, EXPRESSION_KEY, "identifier"],
 
   // tag: title, inside <svelte:head>
   Title: ELEMENT_KEYS,
@@ -28,49 +29,45 @@ const KEYS = evk.unionWith({
 
   // tag: attributes
   Attribute: ["value"],
-  AttributeShorthand: EXPRESSION_KEY,
-  Spread: EXPRESSION_KEY,
+  AttributeShorthand: [EXPRESSION_KEY],
+  Spread: [EXPRESSION_KEY],
 
   // tag: directives
-  Action: EXPRESSION_KEY,
-  Animation: EXPRESSION_KEY,
-  Binding: EXPRESSION_KEY,
-  Class: EXPRESSION_KEY,
-  EventHandler: EXPRESSION_KEY,
-  Let: EXPRESSION_KEY,
-  Ref: EXPRESSION_KEY,
-  Transition: EXPRESSION_KEY,
+  Action: [EXPRESSION_KEY],
+  Animation: [EXPRESSION_KEY],
+  Binding: [EXPRESSION_KEY],
+  Class: [EXPRESSION_KEY],
+  EventHandler: [EXPRESSION_KEY],
+  Let: [EXPRESSION_KEY],
+  Ref: [EXPRESSION_KEY],
+  Transition: [EXPRESSION_KEY],
 
   // mustache: await block
-  AwaitBlock: ["expression", "value", "error", "pending", "then", "catch"],
-  PendingBlock: ["children"],
-  ThenBlock: ["children"],
-  CatchBlock: ["children"],
+  AwaitBlock: [EXPRESSION_KEY, "value", "error", "pending", "then", "catch"],
+  PendingBlock: [CHILDREN_KEY],
+  ThenBlock: [CHILDREN_KEY],
+  CatchBlock: [CHILDREN_KEY],
 
   // mustache: each block
-  EachBlock: ["expression", "context", "index", "key", "children"],
+  EachBlock: [EXPRESSION_KEY, "context", "index", "key", "children"],
 
   // mustache: if
-  IfBlock: ["expression", "children", "else"],
+  IfBlock: [EXPRESSION_KEY, CHILDREN_KEY, "else"],
 
   // mustache: if -> else, elseif; each -> else
-  ElseBlock: ["children"],
+  ElseBlock: [CHILDREN_KEY],
 
   // mustache: @blocks
-  RawMustacheTag: EXPRESSION_KEY,
+  RawMustacheTag: [EXPRESSION_KEY],
   DebugTag: ["identifiers"],
 
   // fragment, tag, mustache: simple text/mustache sequences
   Text: [],
-  MustacheTag: EXPRESSION_KEY
+  MustacheTag: [EXPRESSION_KEY]
 });
 
-function contains_expression_key([_node_type, visitor_keys]) {
-  return visitor_keys.indexOf("expression") > -1;
-}
-
 const EXPRESSION_NODES = Object.entries(KEYS)
-  .filter(contains_expression_key)
-  .map(([node_type]) => node_type);
+  .filter(([_type, keys]) => keys.indexOf(EXPRESSION_KEY) > -1)
+  .map(([type]) => type);
 
 module.exports = { KEYS, EXPRESSION_NODES };

--- a/lib/parser/keys.js
+++ b/lib/parser/keys.js
@@ -1,0 +1,76 @@
+const evk = require("eslint-visitor-keys");
+
+const ELEMENT_KEYS = ["children", "attributes"];
+const EXPRESSION_KEY = ["expression"];
+
+const KEYS = evk.unionWith({
+  // fragment: root
+  Fragment: ["children"],
+
+  // tag: comment
+  Comment: [],
+
+  // tag: meta tags (<svelte:...>)
+  Head: ELEMENT_KEYS,
+  Options: ELEMENT_KEYS,
+  Window: ELEMENT_KEYS,
+  Body: ELEMENT_KEYS,
+
+  // tag: component references, including <svelte:component /> and <svelte:self />
+  InlineComponent: ELEMENT_KEYS,
+
+  // tag: title, inside <svelte:head>
+  Title: ELEMENT_KEYS,
+
+  // tag: normal block tags
+  Slot: ELEMENT_KEYS,
+  Element: ELEMENT_KEYS,
+
+  // tag: attributes
+  Attribute: ["value"],
+  AttributeShorthand: EXPRESSION_KEY,
+  Spread: EXPRESSION_KEY,
+
+  // tag: directives
+  Action: EXPRESSION_KEY,
+  Animation: EXPRESSION_KEY,
+  Binding: EXPRESSION_KEY,
+  Class: EXPRESSION_KEY,
+  EventHandler: EXPRESSION_KEY,
+  Let: EXPRESSION_KEY,
+  Ref: EXPRESSION_KEY,
+  Transition: EXPRESSION_KEY,
+
+  // mustache: await block
+  AwaitBlock: ["expression", "value", "error", "pending", "then", "catch"],
+  PendingBlock: ["children"],
+  ThenBlock: ["children"],
+  CatchBlock: ["children"],
+
+  // mustache: each block
+  EachBlock: ["expression", "context", "index", "key", "children"],
+
+  // mustache: if
+  IfBlock: ["expression", "children", "else"],
+
+  // mustache: if -> else, elseif; each -> else
+  ElseBlock: ["children"],
+
+  // mustache: @blocks
+  RawMustacheTag: EXPRESSION_KEY,
+  DebugTag: ["identifiers"],
+
+  // fragment, tag, mustache: simple text/mustache sequences
+  Text: [],
+  MustacheTag: EXPRESSION_KEY
+});
+
+function contains_expression_key([_node_type, visitor_keys]) {
+  return visitor_keys.indexOf("expression") > -1;
+}
+
+const EXPRESSION_NODES = Object.entries(KEYS)
+  .filter(contains_expression_key)
+  .map(([node_type]) => node_type);
+
+module.exports = { KEYS, EXPRESSION_NODES };

--- a/lib/parser/keys.js
+++ b/lib/parser/keys.js
@@ -17,7 +17,7 @@ const KEYS = evk.unionWith({
   Body: ELEMENT_KEYS,
 
   // tag: component references, including <svelte:component /> and <svelte:self />
-  InlineComponent: ELEMENT_KEYS,
+  InlineComponent: [...ELEMENT_KEYS, ...EXPRESSION_KEY, "identifier"],
 
   // tag: title, inside <svelte:head>
   Title: ELEMENT_KEYS,

--- a/lib/parser/referencer.js
+++ b/lib/parser/referencer.js
@@ -1,5 +1,11 @@
 const { ScopeManager } = require("eslint-scope");
 const Referencer = require("eslint-scope/lib/referencer");
+const {
+  AwaitScope,
+  AwaitThenScope,
+  AwaitCatchScope,
+  EachScope
+} = require("./scope");
 
 class SvelteReferencer extends Referencer {
   Fragment() {
@@ -7,8 +13,11 @@ class SvelteReferencer extends Referencer {
   }
 
   AwaitBlock(node) {
-    // TODO: register variable declarations for `node.value` and `node.error`
-    this.BlockStatement(node);
+    this.scopeManager.__nestScope(
+      new AwaitScope(this.scopeManager, this.currentScope(), node)
+    );
+    this.visitChildren(node);
+    this.close(node);
   }
 
   PendingBlock(node) {
@@ -16,16 +25,27 @@ class SvelteReferencer extends Referencer {
   }
 
   ThenBlock(node) {
-    this.BlockStatement(node);
+    this.scopeManager.__nestScope(
+      new AwaitThenScope(this.scopeManager, this.currentScope(), node)
+    );
+    this.visitChildren(node);
+    this.close(node);
   }
 
   CatchBlock(node) {
-    this.BlockStatement(node);
+    this.scopeManager.__nestScope(
+      new AwaitCatchScope(this.scopeManager, this.currentScope(), node)
+    );
+    this.visitChildren(node);
+    this.close(node);
   }
 
   EachBlock(node) {
-    // TODO: register variable declarations for `node.context`, `node.index`, and `node.key`
-    this.BlockStatement(node);
+    this.scopeManager.__nestScope(
+      new EachScope(this.scopeManager, this.currentScope(), node)
+    );
+    this.visitChildren(node);
+    this.close(node);
   }
 
   IfBlock(node) {

--- a/lib/parser/referencer.js
+++ b/lib/parser/referencer.js
@@ -1,0 +1,71 @@
+const { ScopeManager } = require("eslint-scope");
+const Referencer = require("eslint-scope/lib/referencer");
+
+class SvelteReferencer extends Referencer {
+  Fragment() {
+    throw new Error("Fragment nodes should be converted to Program nodes");
+  }
+
+  AwaitBlock(node) {
+    // TODO: register variable declarations for `node.value` and `node.error`
+    this.BlockStatement(node);
+  }
+
+  PendingBlock(node) {
+    this.BlockStatement(node);
+  }
+
+  ThenBlock(node) {
+    this.BlockStatement(node);
+  }
+
+  CatchBlock(node) {
+    this.BlockStatement(node);
+  }
+
+  EachBlock(node) {
+    // TODO: register variable declarations for `node.context`, `node.index`, and `node.key`
+    this.BlockStatement(node);
+  }
+
+  IfBlock(node) {
+    this.BlockStatement(node);
+  }
+
+  ElseBlock(node) {
+    this.BlockStatement(node);
+  }
+
+  InlineComponent() {
+    // TODO: register variable reference for `node.name` for imported components
+  }
+}
+
+// https://github.com/eslint/eslint-scope/blob/14c092a6efd4dd0bf701bf4f8f518eac6b29b2ce/lib/index.js#L61-L76
+function defaultOptions() {
+  return {
+    optimistic: false,
+    directive: false,
+    nodejsScope: false,
+    impliedStrict: false,
+    sourceType: "script", // one of ['script', 'module']
+    ecmaVersion: 5,
+    childVisitorKeys: null,
+    fallback: "iteration"
+  };
+}
+
+function analyze(ast, providedOptions) {
+  const options = { ...defaultOptions(), ...providedOptions };
+  const manager = new ScopeManager(options);
+  const referencer = new SvelteReferencer(options, manager);
+  referencer.visit(ast);
+
+  if (manager.__currentScope !== null) {
+    throw new Error("currentScope should be null");
+  }
+
+  return manager;
+}
+
+module.exports = { analyze };

--- a/lib/parser/referencer.js
+++ b/lib/parser/referencer.js
@@ -1,5 +1,6 @@
 const { ScopeManager } = require("eslint-scope");
 const Referencer = require("eslint-scope/lib/referencer");
+const { KEYS } = require("./keys");
 const {
   AwaitScope,
   AwaitThenScope,
@@ -56,8 +57,8 @@ class SvelteReferencer extends Referencer {
     this.BlockStatement(node);
   }
 
-  InlineComponent() {
-    // TODO: register variable reference for `node.name` for imported components
+  InlineComponent(node) {
+    this.visitChildren(node);
   }
 }
 
@@ -76,7 +77,11 @@ function defaultOptions() {
 }
 
 function analyze(ast, providedOptions) {
-  const options = { ...defaultOptions(), ...providedOptions };
+  const options = {
+    ...defaultOptions(),
+    ...providedOptions,
+    childVisitorKeys: KEYS
+  };
   const manager = new ScopeManager(options);
   const referencer = new SvelteReferencer(options, manager);
   referencer.visit(ast);

--- a/lib/parser/scope.js
+++ b/lib/parser/scope.js
@@ -1,0 +1,94 @@
+const { Scope } = require("eslint-scope");
+
+class SvelteScope extends Scope {
+  constructor(scopeManager, name, upperScope, block) {
+    super(scopeManager, `svelte:${name}`, upperScope, block, false);
+  }
+
+  __defineExpressionIdentifier(name) {
+    // based on FunctionScope's handling of `arguments` (in eslint-scope)
+    this.__defineGeneric(name, this.set, this.variables, null, null);
+    this.taints.set(name, true);
+  }
+}
+
+class AwaitScope extends SvelteScope {
+  constructor(scopeManager, upperScope, block) {
+    if (block.type !== "AwaitBlock") {
+      throw new Error(`Unexpected block type '${block.type}' for await scope.`);
+    }
+
+    super(scopeManager, "await", upperScope, block);
+  }
+}
+
+class AwaitThenScope extends SvelteScope {
+  constructor(scopeManager, upperScope, block) {
+    if (block.type !== "ThenBlock") {
+      throw new TypeError(
+        `Unexpected block type '${block.type}' for await:then scope.`
+      );
+    }
+
+    if (upperScope.type !== "svelte:await") {
+      throw new TypeError(
+        `Unexpected parent scope '${upperScope.type}' for await:then scope`
+      );
+    }
+
+    super(scopeManager, "await:then", upperScope, block);
+
+    this.__defineExpressionIdentifier(upperScope.block.value);
+  }
+}
+
+class AwaitCatchScope extends SvelteScope {
+  constructor(scopeManager, upperScope, block) {
+    if (block.type !== "CatchBlock") {
+      throw new TypeError(
+        `Unexpected block type '${block.type}' for await:catch scope.`
+      );
+    }
+
+    if (upperScope.type !== "svelte:await") {
+      throw new TypeError(
+        `Unexpected parent scope '${upperScope.type}' for await:catch scope`
+      );
+    }
+
+    super(scopeManager, "await:catch", upperScope, block);
+
+    this.__defineExpressionIdentifier(upperScope.block.error);
+  }
+}
+
+class EachScope extends SvelteScope {
+  constructor(scopeManager, upperScope, block) {
+    if (block.type !== "EachBlock") {
+      throw new Error(`Unexpected block type '${block.type}' for each scope.`);
+    }
+
+    super(scopeManager, "each", upperScope, block);
+
+    this.__defineContext(block.context);
+    if (block.index) {
+      this.__defineExpressionIdentifier(block.index);
+    }
+  }
+
+  __defineContext(node) {
+    const define = this.__defineExpressionIdentifier.bind(this);
+
+    if (node.type === "Identifier") {
+      define(node.name);
+    } else if (node.type === "ObjectPattern") {
+      node.properties.map(property => property.value.name).forEach(define);
+    } else if (node.type === "ArrayPattern") {
+      node.elements.map(element => element.name).forEach(define);
+    } else {
+      throw new Error(`Unexpected each block context node type '${node.type}'`);
+    }
+  }
+}
+
+module.exports = { AwaitScope, AwaitThenScope, AwaitCatchScope, EachScope };

--- a/lib/parser/tokenizer.js
+++ b/lib/parser/tokenizer.js
@@ -1,0 +1,154 @@
+const TAG_NODE_TYPES = [
+  "Head",
+  "Title",
+  "Options",
+  "Window",
+  "Body",
+  "InlineComponent",
+  "Element"
+];
+
+const MUSTACHE_NODE_TYPES = {
+  IfBlock: { start_offset: 0, start_value: "{", end_offset: 0, end_value: "}" },
+  AwaitBlock: {
+    start_offset: 0,
+    start_value: "{",
+    end_offset: 0,
+    end_value: "}"
+  },
+  EachBlock: {
+    start_offset: 0,
+    start_value: "{",
+    end_offset: 0,
+    end_value: "}"
+  },
+  MustacheTag: {
+    start_offset: 0,
+    start_value: "{",
+    end_offset: 0,
+    end_value: "}"
+  },
+  RawMustacheTag: {
+    start_offset: 0,
+    start_value: "{",
+    end_offset: 0,
+    end_value: "}"
+  },
+  DebugTag: {
+    start_offset: 0,
+    start_value: "{",
+    end_offset: 0,
+    end_value: "}"
+  },
+  ElseBlock: {
+    start_offset: -1,
+    start_value: "}",
+    end_offset: 1,
+    end_value: "{"
+  },
+  PendingBlock: {
+    start_offset: -1,
+    start_value: "}",
+    end_offset: 1,
+    end_value: "{"
+  },
+  ThenBlock: {
+    start_offset: 0,
+    start_value: "{",
+    end_offset: 1,
+    end_value: "{"
+  },
+  CatchBlock: {
+    start_offset: 0,
+    start_value: "{",
+    end_offset: 1,
+    end_value: "{"
+  }
+};
+
+function add_mustache_tokens(node, code) {
+  let tokens = [];
+
+  if (MUSTACHE_NODE_TYPES.hasOwnProperty(node.type)) {
+    const {
+      start_offset,
+      start_value,
+      end_offset,
+      end_value
+    } = MUSTACHE_NODE_TYPES[node.type];
+
+    const start_start = node.start + start_offset;
+    const start_end = node.start + start_offset + 1;
+    const end_start = node.end + end_offset - 1;
+    const end_end = node.end + end_offset;
+
+    const actual_start_value = code.slice(start_start, start_end);
+    if (actual_start_value !== start_value) {
+      throw new Error(
+        `Invalid mustache tag token range (${start_start}, ${start_end}): Expected '${start_value}', got '${actual_start_value}`
+      );
+    }
+
+    const actual_end_value = code.slice(end_start, end_end);
+    if (actual_end_value !== end_value) {
+      throw new Error(
+        `Invalid mustache tag token range (${end_start}, ${end_end}): Expected '${end_value}', got '${end_start_value}`
+      );
+    }
+
+    tokens = [
+      {
+        type: "Punctuator",
+        start: start_start,
+        end: start_end,
+        value: start_value
+      },
+      { type: "Punctuator", start: end_start, end: end_end, value: end_value }
+    ];
+  }
+
+  return tokens;
+}
+
+function add_tag_tokens(node) {
+  let tokens = [];
+
+  if (TAG_NODE_TYPES.indexOf(node.type) > -1) {
+    tokens = [
+      {
+        type: "Punctuator",
+        start: node.start,
+        end: node.start + 1,
+        value: "<"
+      },
+      {
+        type: "Punctuator",
+        start: node.end - 1,
+        end: node.end,
+        value: ">"
+      }
+    ];
+  } else if (node.type === "Text") {
+    tokens = [
+      {
+        type: "Text",
+        start: node.start,
+        end: node.end,
+        value: node.data
+      }
+    ];
+  } else if (node.type === "Attribute") {
+    tokens = [
+      {
+        type: "Text",
+        start: node.start,
+        end: node.start + node.name.length,
+        value: node.name
+      }
+    ];
+  }
+
+  return tokens;
+}
+
+module.exports = { add_tag_tokens, add_mustache_tokens };

--- a/lib/parser/tokenizer.js
+++ b/lib/parser/tokenizer.js
@@ -1,45 +1,33 @@
-const TAG_NODE_TYPES = [
-  "Head",
-  "Title",
-  "Options",
-  "Window",
-  "Body",
-  "InlineComponent",
-  "Element"
-];
+const HTML_TAG_LOCATION = {
+  start_offset: 0,
+  start_value: "<",
+  end_offset: 0,
+  end_value: ">"
+};
 
-const MUSTACHE_NODE_TYPES = {
-  IfBlock: { start_offset: 0, start_value: "{", end_offset: 0, end_value: "}" },
-  AwaitBlock: {
-    start_offset: 0,
-    start_value: "{",
-    end_offset: 0,
-    end_value: "}"
-  },
-  EachBlock: {
-    start_offset: 0,
-    start_value: "{",
-    end_offset: 0,
-    end_value: "}"
-  },
-  MustacheTag: {
-    start_offset: 0,
-    start_value: "{",
-    end_offset: 0,
-    end_value: "}"
-  },
-  RawMustacheTag: {
-    start_offset: 0,
-    start_value: "{",
-    end_offset: 0,
-    end_value: "}"
-  },
-  DebugTag: {
-    start_offset: 0,
-    start_value: "{",
-    end_offset: 0,
-    end_value: "}"
-  },
+const DEFAULT_MUSTACHE_LOCATION = {
+  start_offset: 0,
+  start_value: "{",
+  end_offset: 0,
+  end_value: "}"
+};
+
+const TAG_LOCATIONS = {
+  Head: HTML_TAG_LOCATION,
+  Title: HTML_TAG_LOCATION,
+  Options: HTML_TAG_LOCATION,
+  Window: HTML_TAG_LOCATION,
+  Body: HTML_TAG_LOCATION,
+  InlineComponent: HTML_TAG_LOCATION,
+  Element: HTML_TAG_LOCATION,
+
+  IfBlock: DEFAULT_MUSTACHE_LOCATION,
+  AwaitBlock: DEFAULT_MUSTACHE_LOCATION,
+  EachBlock: DEFAULT_MUSTACHE_LOCATION,
+  MustacheTag: DEFAULT_MUSTACHE_LOCATION,
+  RawMustacheTag: DEFAULT_MUSTACHE_LOCATION,
+  DebugTag: DEFAULT_MUSTACHE_LOCATION,
+
   ElseBlock: {
     start_offset: -1,
     start_value: "}",
@@ -66,70 +54,67 @@ const MUSTACHE_NODE_TYPES = {
   }
 };
 
-function add_mustache_tokens(node, code) {
-  let tokens = [];
-
-  if (MUSTACHE_NODE_TYPES.hasOwnProperty(node.type)) {
-    const {
-      start_offset,
-      start_value,
-      end_offset,
-      end_value
-    } = MUSTACHE_NODE_TYPES[node.type];
-
-    const start_start = node.start + start_offset;
-    const start_end = node.start + start_offset + 1;
-    const end_start = node.end + end_offset - 1;
-    const end_end = node.end + end_offset;
-
-    const actual_start_value = code.slice(start_start, start_end);
-    if (actual_start_value !== start_value) {
-      throw new Error(
-        `Invalid mustache tag token range (${start_start}, ${start_end}): Expected '${start_value}', got '${actual_start_value}`
-      );
-    }
-
-    const actual_end_value = code.slice(end_start, end_end);
-    if (actual_end_value !== end_value) {
-      throw new Error(
-        `Invalid mustache tag token range (${end_start}, ${end_end}): Expected '${end_value}', got '${end_start_value}`
-      );
-    }
-
-    tokens = [
-      {
-        type: "Punctuator",
-        start: start_start,
-        end: start_end,
-        value: start_value
-      },
-      { type: "Punctuator", start: end_start, end: end_end, value: end_value }
-    ];
-  }
-
-  return tokens;
+function create_range_error_message(start, end, expected, actual) {
+  return `Invalid tag token range (${start}, ${end}): Expected '${expected}', got '${actual}`;
 }
 
-function add_tag_tokens(node) {
-  let tokens = [];
+function create_tag_tokens(node, code) {
+  if (!TAG_LOCATIONS.hasOwnProperty(node.type)) {
+    return [];
+  }
 
-  if (TAG_NODE_TYPES.indexOf(node.type) > -1) {
-    tokens = [
-      {
-        type: "Punctuator",
-        start: node.start,
-        end: node.start + 1,
-        value: "<"
-      },
-      {
-        type: "Punctuator",
-        start: node.end - 1,
-        end: node.end,
-        value: ">"
-      }
-    ];
-  } else if (node.type === "Text") {
-    tokens = [
+  const { start_offset, start_value, end_offset, end_value } = TAG_LOCATIONS[
+    node.type
+  ];
+
+  const start_start = node.start + start_offset;
+  const start_end = node.start + start_offset + 1;
+  const end_start = node.end + end_offset - 1;
+  const end_end = node.end + end_offset;
+
+  const actual_start_value = code.slice(start_start, start_end);
+  if (actual_start_value !== start_value) {
+    throw new Error(
+      create_range_error_message(
+        start_start,
+        start_end,
+        start_value,
+        actual_start_value
+      )
+    );
+  }
+
+  const actual_end_value = code.slice(end_start, end_end);
+  if (actual_end_value !== end_value) {
+    throw new Error(
+      create_range_error_message(
+        end_start,
+        end_end,
+        end_value,
+        actual_end_value
+      )
+    );
+  }
+
+  return [
+    {
+      type: "Punctuator",
+      start: start_start,
+      end: start_end,
+      value: start_value
+    },
+    {
+      type: "Punctuator",
+      start: end_start,
+      end: end_end,
+      value: end_value
+    }
+  ];
+}
+
+function create_text_tokens(node) {
+  if (node.type === "Text") {
+    return [
       {
         type: "Text",
         start: node.start,
@@ -138,7 +123,7 @@ function add_tag_tokens(node) {
       }
     ];
   } else if (node.type === "Attribute") {
-    tokens = [
+    return [
       {
         type: "Text",
         start: node.start,
@@ -148,7 +133,7 @@ function add_tag_tokens(node) {
     ];
   }
 
-  return tokens;
+  return [];
 }
 
-module.exports = { add_tag_tokens, add_mustache_tokens };
+module.exports = { create_tag_tokens, create_text_tokens };

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1,0 +1,54 @@
+const { Linter } = require("eslint");
+const composer = require("eslint-rule-composer");
+
+const base_rule = new Linter().getRules().get("indent");
+
+const DEFAULT_INDENT_SIZE = 4;
+const TAB_INDENT_SIZE = 1;
+const INDENT_VALUE_MATCH = /^\d+/;
+const PARSE_INT_RADIX = 10;
+
+function ensure_property_is_writable(object, property) {
+  if (!object.hasOwnProperty(property)) {
+    throw new Error(`Property '${property}' does not exist`);
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(object, property);
+  if (!descriptor.writable) {
+    throw new Error(`Property '${property}' is not writable`);
+  }
+}
+
+const map = composer.mapReports(base_rule, (problem, { options }) => {
+  let indentSize = DEFAULT_INDENT_SIZE;
+  if (options.length) {
+    if (options[0] === "tab") {
+      indentSize = TAB_INDENT_SIZE;
+    } else {
+      indentSize = options[0];
+    }
+  }
+
+  // replace entire `data` property since the value is a frozen object
+  ensure_property_is_writable(problem, "data");
+  problem.data = {
+    actual: problem.data.actual,
+    expected: problem.data.expected
+      .toString()
+      .replace(
+        INDENT_VALUE_MATCH,
+        number => parseInt(number, PARSE_INT_RADIX) + indentSize
+      )
+  };
+
+  return problem;
+});
+
+const filter = composer.filterReports(map, ({ data }) => {
+  const [actual] = data.actual.toString().match(INDENT_VALUE_MATCH);
+  const [expected] = data.expected.toString().match(INDENT_VALUE_MATCH);
+
+  return actual !== expected;
+});
+
+module.exports = filter;

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   rules: {
-    "indent": require("./indent"),
+    indent: require("./indent"),
     "no-labels": require("./no-labels"),
     "no-unused-labels": require("./no-unused-labels")
   }

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  rules: {
+    "no-labels": require("./no-labels"),
+    "no-unused-labels": require("./no-unused-labels")
+  }
+};

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
+    "indent": require("./indent"),
     "no-labels": require("./no-labels"),
     "no-unused-labels": require("./no-unused-labels")
   }

--- a/lib/rules/no-labels.js
+++ b/lib/rules/no-labels.js
@@ -1,0 +1,12 @@
+const { Linter } = require("eslint");
+const composer = require("eslint-rule-composer");
+
+const base_rule = new Linter().getRules().get("no-labels");
+
+module.exports = composer.filterReports(base_rule, problem => {
+  if (problem.node.type !== "LabeledStatement") {
+    throw new Error(`Unexpected node type '${problem.node.type}'`);
+  }
+
+  return problem.node.label.name !== "$";
+});

--- a/lib/rules/no-unused-labels.js
+++ b/lib/rules/no-unused-labels.js
@@ -1,0 +1,12 @@
+const { Linter } = require("eslint");
+const composer = require("eslint-rule-composer");
+
+const base_rule = new Linter().getRules().get("no-unused-labels");
+
+module.exports = composer.filterReports(base_rule, problem => {
+  if (problem.node.type !== "Identifier") {
+    throw new Error(`Unexpected node type '${problem.node.type}'`);
+  }
+
+  return problem.node.name !== "$";
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,14 +27,12 @@
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
-      "dev": true
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
     },
     "acorn-jsx": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
-      "dev": true
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
     },
     "ajv": {
       "version": "6.10.0",
@@ -256,7 +254,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
       "integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
-      "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
@@ -271,14 +268,12 @@
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
       "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
-      "dev": true,
       "requires": {
         "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
@@ -304,7 +299,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-      "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
       }
@@ -312,8 +306,7 @@
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -250,6 +250,11 @@
         "text-table": "^0.2.0"
       }
     },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg=="
+    },
     "eslint-scope": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,965 @@
 {
   "name": "@jarrodldavis/eslint-plugin-svelte",
   "version": "0.0.1",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "acorn": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "callsites": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+      "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.0.tgz",
+      "integrity": "sha512-xwG7SS5JLeqkiR3iOmVgtF8Y6xPdtr6AAsN6ph7Q6R/fv+3UlKYoika8SmNzmb35qdRF+RfTY35kMEdtbi+9wg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.9.1",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.2",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.2.2",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
+      "integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "svelte": {
+      "version": "3.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.0.0-beta.10.tgz",
+      "integrity": "sha512-PDA034OwoMwna9+L99QVN/g9fodfxne3+wWaKph4WmcDDn0cAYRzTgu1h8WfAKK7tyt1iTcOBxKP9y+jonJ0/g==",
+      "dev": true
+    },
+    "table": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+      "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.9.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
+          "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,13 @@
   "bugs": {
     "url": "https://github.com/jarrodldavis/eslint-plugin-svelte/issues"
   },
-  "homepage": "https://github.com/jarrodldavis/eslint-plugin-svelte#readme"
+  "homepage": "https://github.com/jarrodldavis/eslint-plugin-svelte#readme",
+  "peerDependencies": {
+    "eslint": "^5.0.0",
+    "svelte": "^3.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^5.15.0",
+    "svelte": "^3.0.0-beta.10"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,5 +31,11 @@
   "devDependencies": {
     "eslint": "^5.15.0",
     "svelte": "^3.0.0-beta.10"
+  },
+  "dependencies": {
+    "eslint-scope": "^4.0.2",
+    "eslint-visitor-keys": "^1.0.0",
+    "espree": "^5.0.1",
+    "estraverse": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "svelte": "^3.0.0-beta.10"
   },
   "dependencies": {
+    "eslint-rule-composer": "^0.3.0",
     "eslint-scope": "^4.0.2",
     "eslint-visitor-keys": "^1.0.0",
     "espree": "^5.0.1",


### PR DESCRIPTION
Add initial implementation of an ESLint parser that converts the Svelte-provided AST into something usable by ESLint and its built-in rules.

- [x] Implement basic conversions of the Svelte-provided AST to a tree that is traversable by ESLint (with `loc` and `range` variables)
    - [x] Re-parse template expressions and `<script>` blocks with `espree` to gather missing tokens and ensure correct node location information (especially relevant for template strings)
    - [x] Add basic tokenization for HTML elements
- [x] Provide scope manager to ESLint so that:
    - [x] variables used in template expressions are marked as used to prevent false positives of the `no-unused-vars` rule
    - [x] variables defined in template blocks (`await` and `then`) are correctly registered and scoped to prevent false positives of the `no-undef` in template expressions
- [x] Add overrides for built-in rules to support JavaScript syntax used in Svelte templates
    - [x] Add overrides for `no-labels` and `no-unused-labels` to filter out reported problems that target `$:` label expressions
    - [x] Add override for `indent` that filters out false positives targeting `<script>` blocks since code in such blocks are typically indented by one indent size