### PR TITLE
Fix position logic

### DIFF
--- a/lib/parser/converter.js
+++ b/lib/parser/converter.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { parse } = require("espree");
+const { getLineInfo } = require("acorn");
 const { VisitorOption } = require("estraverse");
 
 const { EXPRESSION_NODES } = require("./keys");
@@ -22,9 +23,9 @@ function by_range(positionable1, positionable2) {
 }
 
 class Converter extends BaseVisitor {
-  constructor(source, options) {
+  constructor(code, options) {
     super();
-    this.source = source;
+    this.code = code;
     this.options = options;
     this.offset_amount = OFFSET_INACTIVE;
     this.offset_parent = null;
@@ -32,13 +33,20 @@ class Converter extends BaseVisitor {
     this.comments = [];
   }
 
-  _set_loc(node) {
+  _get_line_column(start, end) {
+    return {
+      start: getLineInfo(this.code, start),
+      end: getLineInfo(this.code, end)
+    };
+  }
+
+  _set_location(node) {
     if (Array.isArray(node.range)) {
       throw new Error("Node already has range location information");
     }
 
     node.range = [node.start, node.end];
-    node.loc = this.source.get_loc(node.start, node.end);
+    node.loc = this._get_line_column(node.start, node.end);
   }
 
   _offset_location(node) {
@@ -49,7 +57,7 @@ class Converter extends BaseVisitor {
     node.start += this.offset_amount;
     node.end += this.offset_amount;
     node.range = node.range.map(index => index + this.offset_amount);
-    node.loc = this.source.get_loc(node.start, node.end);
+    node.loc = this._get_line_column(node.start, node.end);
   }
 
   _update_location(node) {
@@ -58,7 +66,7 @@ class Converter extends BaseVisitor {
     }
 
     if (this.offset_amount === OFFSET_INACTIVE) {
-      this._set_loc(node);
+      this._set_location(node);
     } else {
       this._offset_location(node);
     }
@@ -70,7 +78,7 @@ class Converter extends BaseVisitor {
     const start = index + offset;
     const end = index + 1 + offset;
 
-    const actual_value = this.source.code.slice(start, end);
+    const actual_value = this.code.slice(start, end);
     if (actual_value !== value) {
       throw new Error(
         `Invalid tag token range (${start}, ${end}}): Expected '${value}', got '${actual_value}'`
@@ -94,7 +102,7 @@ class Converter extends BaseVisitor {
 
   _parse_js_slice(node) {
     const { start, end } = node;
-    const slice = this.source.code.slice(start, end);
+    const slice = this.code.slice(start, end);
     const program = parse(slice, this.options);
 
     const offset = this._update_location.bind(this);
@@ -128,6 +136,39 @@ class Converter extends BaseVisitor {
     }
 
     return statement.expression;
+  }
+
+  _update_html_body(html, js_instance, js_module) {
+    if (js_instance) {
+      html.body.push(...js_instance.content.body);
+    }
+    if (js_module) {
+      html.body.push(...js_module.content.body);
+    }
+
+    html.body.sort(by_range);
+  }
+
+  _update_html_tokens(html) {
+    html.tokens = this.tokens;
+    html.tokens.sort(by_range);
+
+    html.comments = this.comments;
+    html.comments.sort(by_range);
+  }
+
+  _update_html_location(html) {
+    const first_child = html.tokens[0] || { start: 0 };
+    html.start = first_child.start;
+
+    const last_child = html.tokens[html.tokens.length - 1] || {
+      end: this.code.length
+    };
+    html.end = last_child.end;
+
+    delete html.range;
+
+    this._set_location(html);
   }
 
   "*"(node) {
@@ -267,21 +308,9 @@ class Converter extends BaseVisitor {
   }
 
   "TemplateRoot:leave"(node) {
-    const { html, instance: js_instance, module: js_module } = node;
-
-    if (js_instance) {
-      html.body.push(...js_instance.content.body);
-    }
-    if (js_module) {
-      html.body.push(...js_module.content.body);
-    }
-    html.body.sort(by_range);
-
-    html.tokens = this.tokens;
-    html.tokens.sort(by_range);
-
-    html.comments = this.comments;
-    html.comments.sort(by_range);
+    this._update_html_body(node.html, node.instance, node.module);
+    this._update_html_tokens(node.html);
+    this._update_html_location(node.html);
   }
 }
 

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -2,7 +2,6 @@
 
 const { compile } = require("svelte/compiler");
 
-const { SourceCode } = require("./source-code");
 const { Converter } = require("./converter");
 const { analyze } = require("./referencer");
 const { KEYS } = require("./keys");
@@ -27,7 +26,7 @@ function parse(code, options) {
   const result = compile_template(code);
 
   result.ast.type = "TemplateRoot";
-  const converter = new Converter(new SourceCode(code), options);
+  const converter = new Converter(code, options);
   converter.visit(result.ast);
 
   const {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "svelte": "^3.0.0-beta.11"
   },
   "dependencies": {
+    "acorn": "^6.1.1",
     "eslint-rule-composer": "^0.3.0",
     "eslint-scope": "^4.0.2",
     "eslint-visitor-keys": "^1.0.0",


### PR DESCRIPTION
- [x] Use `acorn`'s logic for retrieving line/column position info to ensure ESLint's expectation for `loc` values are met
- [x] Update the HTML root node (which is provided as the root ast node to ESLint) location based on the first and last token across from template and `<script>` blocks