### PR TITLE
Improve parsing of JavaScript

### DIFF
--- a/lib/parser/converter/converter.js
+++ b/lib/parser/converter/converter.js
@@ -1,25 +1,34 @@
 "use strict";
 
-const { parse } = require("espree");
 const { getLineInfo } = require("acorn");
 const { VisitorOption } = require("estraverse");
 
 const { EXPRESSION_NODES } = require("../keys");
 const { TAG_LOCATIONS } = require("./tag-locations");
+const { get_parser } = require("./espree");
 const { BaseVisitor } = require("./base-visitor");
 
 const EXPRESSION_NODE_ENTER = EXPRESSION_NODES.map(
   type => `${type} > .expression`
 ).join(", ");
-const EXPRESSION_NODE_LEAVE = `${EXPRESSION_NODE_ENTER}:leave`;
 const TAG_NODE_ENTER = Object.keys(TAG_LOCATIONS).join(", ");
 const IMPORTED_COMPONENT_REFERENCE = "InlineComponent[name=/^[A-Z]/]";
 
-const OFFSET_INACTIVE = -1;
 const TRAVERSAL_MARKER = Symbol("eslint-plugin-svelte traversal marker");
 
 function by_range(positionable1, positionable2) {
   return positionable1.range[0] - positionable2.range[0];
+}
+
+function parseExpressionAt(code, base_options, position) {
+  const Parser = get_parser(position);
+  const parser = new Parser(base_options, code);
+
+  parser.nextToken();
+  const expression = parser.parseExpression();
+
+  const { tokens, comments } = parser.get_extras();
+  return { expression, tokens, comments };
 }
 
 class Converter extends BaseVisitor {
@@ -27,37 +36,8 @@ class Converter extends BaseVisitor {
     super();
     this.code = code;
     this.options = options;
-    this.offset_amount = OFFSET_INACTIVE;
-    this.offset_parent = null;
     this.tokens = [];
     this.comments = [];
-  }
-
-  _get_line_column(start, end) {
-    return {
-      start: getLineInfo(this.code, start),
-      end: getLineInfo(this.code, end)
-    };
-  }
-
-  _set_location(node) {
-    if (Array.isArray(node.range)) {
-      throw new Error("Node already has range location information");
-    }
-
-    node.range = [node.start, node.end];
-    node.loc = this._get_line_column(node.start, node.end);
-  }
-
-  _offset_location(node) {
-    if (!Array.isArray(node.range)) {
-      throw new Error("Node requires range location information");
-    }
-
-    node.start += this.offset_amount;
-    node.end += this.offset_amount;
-    node.range = node.range.map(index => index + this.offset_amount);
-    node.loc = this._get_line_column(node.start, node.end);
   }
 
   _update_location(node) {
@@ -65,11 +45,15 @@ class Converter extends BaseVisitor {
       throw new Error("Node requires start and end location information");
     }
 
-    if (this.offset_amount === OFFSET_INACTIVE) {
-      this._set_location(node);
-    } else {
-      this._offset_location(node);
+    if (Array.isArray(node.range) || node.loc instanceof Object) {
+      return node;
     }
+
+    node.range = [node.start, node.end];
+    node.loc = {
+      start: getLineInfo(this.code, node.start),
+      end: getLineInfo(this.code, node.end)
+    };
 
     return node;
   }
@@ -90,52 +74,25 @@ class Converter extends BaseVisitor {
     );
   }
 
-  _enter_offset_parent(node) {
-    this.offset_amount = node.start;
-    this.offset_parent = node;
-  }
-
-  _leave_offset_parent() {
-    this.offset_amount = OFFSET_INACTIVE;
-    this.offset_parent = null;
-  }
-
-  _parse_js_slice(node) {
-    const { start, end } = node;
-    const slice = this.code.slice(start, end);
-    const program = parse(slice, this.options);
-
-    const offset = this._update_location.bind(this);
-    this.tokens.push(...program.tokens.map(offset));
-    this.comments.push(...program.comments.map(offset));
-
-    return program;
-  }
-
   _parse_template_expression(node) {
-    const {
-      body: [statement]
-    } = this._parse_js_slice(node);
+    const { expression, tokens, comments } = parseExpressionAt(
+      this.code,
+      this.options,
+      node.start
+    );
 
-    if (!statement) {
-      throw new Error("Failed to parse template expression");
-    }
-
-    if (statement.type !== "ExpressionStatement") {
-      throw new Error(
-        "Unexpected non-expression parse result for template expression"
-      );
-    }
-
-    if (statement.expression.type !== node.type) {
+    if (expression.type !== node.type) {
       throw new Error(
         `Parse result mismatch for template expression: expected '${
           node.type
-        }', got '${statement.expression.type}'`
+        }', got '${expression.type}'`
       );
     }
 
-    return statement.expression;
+    const offset = this._update_location.bind(this);
+    this.tokens.push(...tokens.map(offset));
+    this.comments.push(...comments.map(offset));
+    return expression;
   }
 
   _update_html_body(html, js_instance, js_module) {
@@ -167,8 +124,8 @@ class Converter extends BaseVisitor {
     html.end = last_child.end;
 
     delete html.range;
-
-    this._set_location(html);
+    delete html.loc;
+    this._update_location(html);
   }
 
   "*"(node) {
@@ -243,12 +200,7 @@ class Converter extends BaseVisitor {
   }
 
   [EXPRESSION_NODE_ENTER](node) {
-    this._enter_offset_parent(node);
     return this._parse_template_expression(node);
-  }
-
-  [EXPRESSION_NODE_LEAVE]() {
-    this._leave_offset_parent();
   }
 
   [IMPORTED_COMPONENT_REFERENCE](node) {
@@ -261,30 +213,15 @@ class Converter extends BaseVisitor {
   }
 
   [`${IMPORTED_COMPONENT_REFERENCE} > .identifier`](node) {
-    this._enter_offset_parent(node);
     return this._parse_template_expression(node);
-  }
-
-  [`${IMPORTED_COMPONENT_REFERENCE} > .identifier:leave`]() {
-    this._leave_offset_parent();
   }
 
   "EachBlock > .context"(node) {
-    this._enter_offset_parent(node);
     return this._parse_template_expression(node);
-  }
-
-  "EachBlock > .context:leave"(node) {
-    this._leave_offset_parent(node);
   }
 
   "EachBlock > .key"(node) {
-    this._enter_offset_parent(node);
     return this._parse_template_expression(node);
-  }
-
-  "EachBlock > .key:leave"(node) {
-    this._leave_offset_parent(node);
   }
 
   "Fragment:leave"(node) {
@@ -299,12 +236,12 @@ class Converter extends BaseVisitor {
   }
 
   "ScriptElement > .content"(node) {
-    this._enter_offset_parent(node);
-    return this._parse_js_slice(node);
-  }
-
-  "ScriptElement > .content:leave"() {
-    this._leave_offset_parent();
+    const Parser = get_parser(node.start);
+    const program = Parser.parse(this.code.slice(0, node.end), this.options);
+    const offset = this._update_location.bind(this);
+    this.tokens.push(...program.tokens.map(offset));
+    this.comments.push(...program.comments.map(offset));
+    return program;
   }
 
   "TemplateRoot:leave"(node) {

--- a/lib/parser/converter/converter.js
+++ b/lib/parser/converter/converter.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { getLineInfo } = require("acorn");
+const { getLineInfo, tokTypes, Token } = require("acorn");
 const { VisitorOption } = require("estraverse");
 
 const { EXPRESSION_NODES } = require("../keys");
@@ -20,12 +20,29 @@ function by_range(positionable1, positionable2) {
   return positionable1.range[0] - positionable2.range[0];
 }
 
-function parseExpressionAt(code, base_options, position) {
+function parseExpressionAt(code, base_options, position, assignable) {
   const Parser = get_parser(position);
   const parser = new Parser(base_options, code);
 
   parser.nextToken();
-  const expression = parser.parseExpression();
+
+  const destructuring_errors = {
+    shorthandAssign: -1,
+    trailingComma: -1,
+    parenthesizedAssign: -1,
+    parenthesizedBind: -1,
+    doubleProto: -1
+  };
+
+  let expression = parser.parseExpression(undefined, destructuring_errors);
+  if (assignable) {
+    expression = parser.toAssignable(expression, false, destructuring_errors);
+    parser.checkLVal(expression);
+  }
+
+  // espree holds closing curly braces hostage until the next token
+  parser.finishToken(tokTypes.eof);
+  parser.options.onToken(new Token(parser));
 
   const { tokens, comments } = parser.get_extras();
   return { expression, tokens, comments };
@@ -74,11 +91,12 @@ class Converter extends BaseVisitor {
     );
   }
 
-  _parse_template_expression(node) {
+  _parse_template_expression(node, assignable = false) {
     const { expression, tokens, comments } = parseExpressionAt(
       this.code,
       this.options,
-      node.start
+      node.start,
+      assignable
     );
 
     if (expression.type !== node.type) {
@@ -217,7 +235,7 @@ class Converter extends BaseVisitor {
   }
 
   "EachBlock > .context"(node) {
-    return this._parse_template_expression(node);
+    return this._parse_template_expression(node, true);
   }
 
   "EachBlock > .key"(node) {

--- a/lib/parser/converter/espree.js
+++ b/lib/parser/converter/espree.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const acorn = require("acorn");
+const espree = require("espree/lib/espree");
+
+function svelte(position) {
+  return function extend(Parser) {
+    return class SvelteEspreeParser extends Parser {
+      constructor(options, code) {
+        // work around espree not allowing start position argument
+        super(options, code, position);
+      }
+
+      get_extras() {
+        const state_symbol = Object.getOwnPropertySymbols(this).find(
+          symbol => symbol.description === "espree's internal state"
+        );
+
+        if (!state_symbol) {
+          throw new Error("Could not find espree state");
+        }
+
+        const { tokens, comments } = this[state_symbol];
+
+        return { tokens, comments };
+      }
+    };
+  };
+}
+
+function get_parser(position) {
+  return acorn.Parser.extend(svelte(position), espree());
+}
+
+module.exports = { get_parser };

--- a/lib/parser/referencer/index.js
+++ b/lib/parser/referencer/index.js
@@ -4,8 +4,24 @@ const { ScopeManager } = require("eslint-scope");
 const { KEYS } = require("../keys");
 const { SvelteReferencer } = require("./referencer");
 
+/**
+ * Context expressions for each blocks are functionally similar to
+ * `VariableDeclaration` nodes, whose children are not recursively visited by
+ * `eslint-scope`; this is to prevent duplicate references for initializer
+ * identifiers.
+ *
+ * The following excludes the `context` key from being automatically visited
+ * since `EachScope` handles creating variables and referencers for context
+ * expressions in much the same way as `VariableDeclaration` nodes are handled
+ * by `eslint-scope`.
+ */
+const visitor_keys = JSON.parse(JSON.stringify(KEYS));
+visitor_keys.EachBlock = visitor_keys.EachBlock.filter(
+  key => key !== "context"
+);
+
 // https://github.com/eslint/eslint-scope/blob/14c092a6efd4dd0bf701bf4f8f518eac6b29b2ce/lib/index.js#L61-L76
-function defaultOptions() {
+function default_options() {
   return {
     optimistic: false,
     directive: false,
@@ -20,9 +36,9 @@ function defaultOptions() {
 
 function analyze(ast, providedOptions) {
   const options = {
-    ...defaultOptions(),
+    ...default_options(),
     ...providedOptions,
-    childVisitorKeys: KEYS
+    childVisitorKeys: visitor_keys
   };
   const manager = new ScopeManager(options);
   const referencer = new SvelteReferencer(options, manager);

--- a/lib/parser/referencer/scope.js
+++ b/lib/parser/referencer/scope.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line max-classes-per-file
 "use strict";
-const { Scope, Variable } = require("eslint-scope");
+const { Scope, Variable, Reference } = require("eslint-scope");
 const { Definition } = require("eslint-scope/lib/definition");
 
 class SvelteScope extends Scope {
@@ -11,6 +11,7 @@ class SvelteScope extends Scope {
   __defineTemplate(name, node) {
     const definition = new Definition(Variable.Variable, name, node);
     this.__defineGeneric(name, this.set, this.variables, node, definition);
+    this.__referencing(node, Reference.WRITE, node, null, false, true);
   }
 }
 


### PR DESCRIPTION
- [x] Refactor parsing of template expressions and script blocks by using an extended acorn/Espree parser that restores the ability to adjust the start position while maintaining Espree's quirks for Esprima compatibility
- [x] Remove offset management from `Converter` since the parser start position adjustment handles that automatically
- [x] Fix parsing of `EachBlock` context expressions by ensuring all tokens are relinquished from Espree and fixing scopes to use initialization/write-only (instead of read-only) references