### PR TITLE
Refactor `Converter` into mixins

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,6 @@
     "no-ternary": "off",
     "class-methods-use-this": "off",
     "no-underscore-dangle": "off",
-    "max-lines": ["error", 500],
     "max-statements": ["error", 15],
     "no-undefined": "off",
     "node/exports-style": ["error", "module.exports"],

--- a/lib/parser/converter/base-visitor.js
+++ b/lib/parser/converter/base-visitor.js
@@ -17,7 +17,7 @@ function* get_handlers(visitor) {
 
   while (object && object !== Object.prototype) {
     for (const key of Object.getOwnPropertyNames(object)) {
-      if (key.startsWith("_") || key === "constructor" || key === "visit") {
+      if (key === "constructor" || key === "visit") {
         continue;
       }
 

--- a/lib/parser/converter/base-visitor.js
+++ b/lib/parser/converter/base-visitor.js
@@ -5,6 +5,13 @@ const { matches, parse: parse_query } = require("esquery");
 
 const { KEYS } = require("../keys");
 
+const ANCESTRY = Symbol("BaseVisitor.ancestry");
+const HANDLERS = Symbol("BaseVisitor.handlers");
+const ENTER = Symbol("BaseVisitor.enter()");
+const LEAVE = Symbol("BaseVisitor.leave()");
+const HANDLER_LOOP = Symbol("BaseVisitor.handler_loop()");
+const EXECUTE_HANDLER = Symbol("BaseVisitor.execute_handler()");
+
 function* get_handlers(visitor) {
   let object = visitor;
 
@@ -49,10 +56,10 @@ class BaseVisitor {
       throw new Error("BaseVisitor must be subclassed to be instantiated");
     }
 
-    this.current_ancestry = [];
-    this.handlers = compile_handlers(this);
+    this[ANCESTRY] = [];
+    this[HANDLERS] = compile_handlers(this);
 
-    if (this.handlers.length === 0) {
+    if (this[HANDLERS].length === 0) {
       throw new Error(
         `Visitor class '${this.constructor.name}' has no handlers defind.`
       );
@@ -61,32 +68,32 @@ class BaseVisitor {
 
   visit(root) {
     replace(root, {
-      enter: this._enter.bind(this),
-      leave: this._leave.bind(this),
+      enter: this[ENTER].bind(this),
+      leave: this[LEAVE].bind(this),
       keys: KEYS,
       fallback: "iteration"
     });
 
-    if (this.current_ancestry.length > 0) {
+    if (this[ANCESTRY].length > 0) {
       throw new Error("Unexpected dangling ancestry entries");
     }
   }
 
-  _enter(node, parent) {
+  [ENTER](node, parent) {
     // when entering the root node, estraverse sets `parent` to that root node
     if (parent && parent !== node) {
-      this.current_ancestry.unshift(parent);
+      this[ANCESTRY].unshift(parent);
     }
 
-    return this._handler_loop(node, "enter");
+    return this[HANDLER_LOOP](node, "enter");
   }
 
-  _leave(node, parent) {
-    const return_value = this._handler_loop(node, "leave");
+  [LEAVE](node, parent) {
+    const return_value = this[HANDLER_LOOP](node, "leave");
 
     // when leaving the root node, estraverse sets `parent` to that root node
     if (parent && parent !== node) {
-      const removed = this.current_ancestry.shift();
+      const removed = this[ANCESTRY].shift();
       if (removed === undefined) {
         throw new Error("Unexpected empty ancestry list");
       }
@@ -95,21 +102,21 @@ class BaseVisitor {
     return return_value;
   }
 
-  _handler_loop(node, direction) {
+  [HANDLER_LOOP](node, direction) {
     const return_values = [];
 
-    for (const handler of this.handlers) {
-      const return_value = this._execute_handler(node, direction, handler);
+    for (const handler of this[HANDLERS]) {
+      const return_value = this[EXECUTE_HANDLER](node, direction, handler);
 
       if (return_value === VisitorOption.Skip) {
         return return_value;
       } else if (return_value === VisitorOption.Break) {
         // leave handlers for all nodes are not called when estraverse breaks traversal
-        this.current_ancestry = [];
+        this[ANCESTRY] = [];
         return return_value;
       } else if (return_value === VisitorOption.Remove) {
         // leave handler for current node is not called when estraverse removes a node
-        this.current_ancestry.shift();
+        this[ANCESTRY].shift();
         return return_value;
       } else if (return_value) {
         return_values.push(return_value);
@@ -123,12 +130,12 @@ class BaseVisitor {
     }
   }
 
-  _execute_handler(node, traversal_direction, handler) {
+  [EXECUTE_HANDLER](node, traversal_direction, handler) {
     if (handler.traversal_direction !== traversal_direction) {
       return null;
     }
 
-    if (!matches(node, handler.query, this.current_ancestry)) {
+    if (!matches(node, handler.query, this[ANCESTRY])) {
       return null;
     }
 

--- a/lib/parser/converter/base-visitor.js
+++ b/lib/parser/converter/base-visitor.js
@@ -5,52 +5,52 @@ const { matches, parse: parse_query } = require("esquery");
 
 const { KEYS } = require("../keys");
 
-class BaseVisitor {
-  static *get_handlers(visitor) {
-    let object = visitor;
+function* get_handlers(visitor) {
+  let object = visitor;
 
-    while (object && object !== Object.prototype) {
-      for (const key of Object.getOwnPropertyNames(object)) {
-        if (key.startsWith("_") || key === "constructor" || key === "visit") {
-          continue;
-        }
-
-        const value = Reflect.get(object, key);
-
-        if (typeof value !== "function") {
-          continue;
-        }
-
-        yield [key, value];
+  while (object && object !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(object)) {
+      if (key.startsWith("_") || key === "constructor" || key === "visit") {
+        continue;
       }
 
-      object = Object.getPrototypeOf(object);
-    }
-  }
+      const value = Reflect.get(object, key);
 
-  static compile_handlers(visitor) {
-    const handlers = [];
+      if (typeof value !== "function") {
+        continue;
+      }
 
-    for (const [query, handler] of BaseVisitor.get_handlers(visitor)) {
-      const is_leave = query.endsWith(":leave");
-      const normalized_query = query.replace(/:leave$/u, "");
-      handlers.push({
-        query: parse_query(normalized_query),
-        traversal_direction: is_leave ? "leave" : "enter",
-        handler: handler.bind(visitor)
-      });
+      yield [key, value];
     }
 
-    return handlers;
+    object = Object.getPrototypeOf(object);
+  }
+}
+
+function compile_handlers(visitor) {
+  const handlers = [];
+
+  for (const [query, handler] of get_handlers(visitor)) {
+    const is_leave = query.endsWith(":leave");
+    const normalized_query = query.replace(/:leave$/u, "");
+    handlers.push({
+      query: parse_query(normalized_query),
+      traversal_direction: is_leave ? "leave" : "enter",
+      handler: handler.bind(visitor)
+    });
   }
 
+  return handlers;
+}
+
+class BaseVisitor {
   constructor() {
     if (Object.getPrototypeOf(this) === BaseVisitor.prototype) {
       throw new Error("BaseVisitor must be subclassed to be instantiated");
     }
 
     this.current_ancestry = [];
-    this.handlers = BaseVisitor.compile_handlers(this);
+    this.handlers = compile_handlers(this);
 
     if (this.handlers.length === 0) {
       throw new Error(

--- a/lib/parser/converter/converter.js
+++ b/lib/parser/converter/converter.js
@@ -1,149 +1,35 @@
 "use strict";
 
-const { getLineInfo, tokTypes, Token } = require("acorn");
 const { VisitorOption } = require("estraverse");
 
-const { EXPRESSION_NODES } = require("../keys");
-const { TAG_LOCATIONS } = require("./tag-locations");
-const { get_parser } = require("./espree");
 const { BaseVisitor } = require("./base-visitor");
+const { mix } = require("./mixin-builder");
+const { ExpressionParserMixin } = require("./expression-parser");
+const { ScriptBlockParserMixin } = require("./script-block-parser");
+const { PositionUpdaterMixin } = require("./position-updater");
+const { TagTokenizerMixin } = require("./tag-tokenizer");
 
-const EXPRESSION_NODE_ENTER = EXPRESSION_NODES.map(
-  type => `${type} > .expression`
-).join(", ");
-const TAG_NODE_ENTER = Object.keys(TAG_LOCATIONS).join(", ");
-const IMPORTED_COMPONENT_REFERENCE = "InlineComponent[name=/^[A-Z]/]";
+const MixedInVisitor = mix(BaseVisitor).with(
+  ExpressionParserMixin,
+  ScriptBlockParserMixin,
+  PositionUpdaterMixin,
+  TagTokenizerMixin
+);
 
 const TRAVERSAL_MARKER = Symbol("eslint-plugin-svelte traversal marker");
 
-function by_range(positionable1, positionable2) {
-  return positionable1.range[0] - positionable2.range[0];
-}
+const CODE = Symbol("Converter.code");
+const TOKENS = Symbol("Converter.tokens");
+const COMMENTS = Symbol("Converter.comments");
 
-function parseExpressionAt(code, base_options, position, assignable) {
-  const Parser = get_parser(position);
-  const parser = new Parser(base_options, code);
-
-  parser.nextToken();
-
-  const destructuring_errors = {
-    shorthandAssign: -1,
-    trailingComma: -1,
-    parenthesizedAssign: -1,
-    parenthesizedBind: -1,
-    doubleProto: -1
-  };
-
-  let expression = parser.parseExpression(undefined, destructuring_errors);
-  if (assignable) {
-    expression = parser.toAssignable(expression, false, destructuring_errors);
-    parser.checkLVal(expression);
-  }
-
-  // espree holds closing curly braces hostage until the next token
-  parser.finishToken(tokTypes.eof);
-  parser.options.onToken(new Token(parser));
-
-  const { tokens, comments } = parser.get_extras();
-  return { expression, tokens, comments };
-}
-
-class Converter extends BaseVisitor {
+class Converter extends MixedInVisitor {
   constructor(code, options) {
-    super();
-    this.code = code;
-    this.options = options;
-    this.tokens = [];
-    this.comments = [];
-  }
-
-  _update_location(node) {
-    if (!Number.isInteger(node.start) || !Number.isInteger(node.end)) {
-      throw new Error("Node requires start and end location information");
-    }
-
-    if (Array.isArray(node.range) || node.loc instanceof Object) {
-      return node;
-    }
-
-    node.range = [node.start, node.end];
-    node.loc = {
-      start: getLineInfo(this.code, node.start),
-      end: getLineInfo(this.code, node.end)
-    };
-
-    return node;
-  }
-
-  _add_tag_token(index, offset, value) {
-    const start = index + offset;
-    const end = index + 1 + offset;
-
-    const actual_value = this.code.slice(start, end);
-    if (actual_value !== value) {
-      throw new Error(
-        `Invalid tag token range (${start}, ${end}}): Expected '${value}', got '${actual_value}'`
-      );
-    }
-
-    this.tokens.push(
-      this._update_location({ type: "Punctuator", start, end, value })
-    );
-  }
-
-  _parse_template_expression(node, assignable = false) {
-    const { expression, tokens, comments } = parseExpressionAt(
-      this.code,
-      this.options,
-      node.start,
-      assignable
-    );
-
-    if (expression.type !== node.type) {
-      throw new Error(
-        `Parse result mismatch for template expression: expected '${
-          node.type
-        }', got '${expression.type}'`
-      );
-    }
-
-    const offset = this._update_location.bind(this);
-    this.tokens.push(...tokens.map(offset));
-    this.comments.push(...comments.map(offset));
-    return expression;
-  }
-
-  _update_html_body(html, js_instance, js_module) {
-    if (js_instance) {
-      html.body.push(...js_instance.content.body);
-    }
-    if (js_module) {
-      html.body.push(...js_module.content.body);
-    }
-
-    html.body.sort(by_range);
-  }
-
-  _update_html_tokens(html) {
-    html.tokens = this.tokens;
-    html.tokens.sort(by_range);
-
-    html.comments = this.comments;
-    html.comments.sort(by_range);
-  }
-
-  _update_html_location(html) {
-    const first_child = html.tokens[0] || { start: 0 };
-    html.start = first_child.start;
-
-    const last_child = html.tokens[html.tokens.length - 1] || {
-      end: this.code.length
-    };
-    html.end = last_child.end;
-
-    delete html.range;
-    delete html.loc;
-    this._update_location(html);
+    const tokens = [];
+    const comments = [];
+    super({ code, parser_options: options, tokens, comments });
+    this[CODE] = code;
+    this[TOKENS] = tokens;
+    this[COMMENTS] = comments;
   }
 
   "*"(node) {
@@ -152,10 +38,6 @@ class Converter extends BaseVisitor {
     }
 
     node[TRAVERSAL_MARKER] = true;
-  }
-
-  ":not(TemplateRoot, WhiteSpace):leave"(node) {
-    this._update_location(node);
   }
 
   // prevent duplicate traversal of shorthand property keys
@@ -169,6 +51,10 @@ class Converter extends BaseVisitor {
     if (!node.value) {
       node.value = node.key;
     }
+  }
+
+  WhiteSpace() {
+    return VisitorOption.Remove;
   }
 
   TemplateRoot(node) {
@@ -187,85 +73,23 @@ class Converter extends BaseVisitor {
     }
   }
 
-  Text(node) {
-    this.tokens.push(
-      this._update_location({
-        type: "Text",
-        start: node.start,
-        end: node.end,
-        value: node.data
-      })
-    );
-  }
-
-  Attribute(node) {
-    this.tokens.push(
-      this._update_location({
-        type: "Text",
-        start: node.start,
-        end: node.start + node.name.length,
-        value: node.name
-      })
-    );
-  }
-
-  [TAG_NODE_ENTER](node) {
-    const { start_offset, start_value } = TAG_LOCATIONS[node.type];
-    this._add_tag_token(node.start, start_offset, start_value);
-
-    const { end_offset, end_value } = TAG_LOCATIONS[node.type];
-    this._add_tag_token(node.end - 1, end_offset, end_value);
-  }
-
-  [EXPRESSION_NODE_ENTER](node) {
-    return this._parse_template_expression(node);
-  }
-
-  [IMPORTED_COMPONENT_REFERENCE](node) {
-    node.identifier = {
-      type: "Identifier",
-      name: node.name,
-      start: node.start + 1,
-      end: node.start + 1 + node.name.length
-    };
-  }
-
-  [`${IMPORTED_COMPONENT_REFERENCE} > .identifier`](node) {
-    return this._parse_template_expression(node);
-  }
-
-  "EachBlock > .context"(node) {
-    return this._parse_template_expression(node, true);
-  }
-
-  "EachBlock > .key"(node) {
-    return this._parse_template_expression(node);
-  }
-
-  "Fragment:leave"(node) {
-    node.type = "Program";
-    node.sourceType = "module";
-    node.body = node.children;
-    delete node.children;
-  }
-
-  WhiteSpace() {
-    return VisitorOption.Remove;
-  }
-
-  "ScriptElement > .content"(node) {
-    const Parser = get_parser(node.start);
-    const program = Parser.parse(this.code.slice(0, node.end), this.options);
-    const offset = this._update_location.bind(this);
-    this.tokens.push(...program.tokens.map(offset));
-    this.comments.push(...program.comments.map(offset));
-    return program;
-  }
-
   "TemplateRoot:leave"(node) {
-    this._update_html_body(node.html, node.instance, node.module);
-    this._update_html_tokens(node.html);
-    this._update_html_location(node.html);
+    const { html, instance: js_instance, module: js_module } = node;
+
+    html.type = "Program";
+    html.sourceType = "module";
+    html.body = html.children;
+    delete html.children;
+
+    if (js_instance) {
+      html.body.push(...js_instance.content.body);
+    }
+    if (js_module) {
+      html.body.push(...js_module.content.body);
+    }
+
+    html.tokens = this[TOKENS];
+    html.comments = this[COMMENTS];
   }
 }
 

--- a/lib/parser/converter/expression-parser.js
+++ b/lib/parser/converter/expression-parser.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const { tokTypes, Token } = require("acorn");
+
+const { get_parser } = require("./espree");
+const { EXPRESSION_NODES } = require("../keys");
+
+const CODE = Symbol("ExpressionParser.code");
+const PARSER_OPTIONS = Symbol("ExpressionParser.parser_options");
+const TOKENS = Symbol("ExpressionParser.tokens");
+const COMMENTS = Symbol("ExpressionParser.comments");
+const PARSE_EXPRESSION = Symbol("ExpressionParser.parse_expression()");
+
+const IMPORTED_COMPONENT_REFERENCE = "InlineComponent[name=/^[A-Z]/]";
+const EXPRESSION_NODE_ENTER = EXPRESSION_NODES.map(
+  type => `${type} > .expression`
+).join(", ");
+
+function parseExpressionAt(code, base_options, position, assignable) {
+  const Parser = get_parser(position);
+  const parser = new Parser(base_options, code);
+
+  parser.nextToken();
+
+  const destructuring_errors = {
+    shorthandAssign: -1,
+    trailingComma: -1,
+    parenthesizedAssign: -1,
+    parenthesizedBind: -1,
+    doubleProto: -1
+  };
+
+  let expression = parser.parseExpression(undefined, destructuring_errors);
+  if (assignable) {
+    expression = parser.toAssignable(expression, false, destructuring_errors);
+    parser.checkLVal(expression);
+  }
+
+  // espree holds closing curly braces hostage until the next token
+  parser.finishToken(tokTypes.eof);
+  parser.options.onToken(new Token(parser));
+
+  const { tokens, comments } = parser.get_extras();
+  return { expression, tokens, comments };
+}
+
+// eslint-disable-next-line max-lines-per-function
+function ExpressionParserMixin(SuperClass) {
+  return class ExpressionParser extends SuperClass {
+    constructor(options) {
+      super(options);
+      this[CODE] = options.code;
+      this[PARSER_OPTIONS] = options.parser_options;
+      this[TOKENS] = options.tokens;
+      this[COMMENTS] = options.comments;
+    }
+
+    [PARSE_EXPRESSION](node, assignable = false) {
+      const { expression, tokens, comments } = parseExpressionAt(
+        this[CODE],
+        this[PARSER_OPTIONS],
+        node.start,
+        assignable
+      );
+
+      if (expression.type !== node.type) {
+        throw new Error(
+          `Parse result mismatch for template expression: expected '${
+            node.type
+          }', got '${expression.type}'`
+        );
+      }
+
+      this[TOKENS].push(...tokens);
+      this[COMMENTS].push(...comments);
+
+      return expression;
+    }
+
+    [IMPORTED_COMPONENT_REFERENCE](node) {
+      node.identifier = {
+        type: "Identifier",
+        name: node.name,
+        start: node.start + 1,
+        end: node.start + 1 + node.name.length
+      };
+    }
+
+    [`${IMPORTED_COMPONENT_REFERENCE} > .identifier`](node) {
+      return this[PARSE_EXPRESSION](node);
+    }
+
+    [EXPRESSION_NODE_ENTER](node) {
+      return this[PARSE_EXPRESSION](node);
+    }
+
+    "EachBlock > .context"(node) {
+      return this[PARSE_EXPRESSION](node, true);
+    }
+
+    "EachBlock > .key"(node) {
+      return this[PARSE_EXPRESSION](node);
+    }
+  };
+}
+
+module.exports = { ExpressionParserMixin };

--- a/lib/parser/converter/mixin-builder.js
+++ b/lib/parser/converter/mixin-builder.js
@@ -1,0 +1,21 @@
+"use strict";
+
+// http://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/
+class MixinBuilder {
+  constructor(superclass) {
+    this.superclass = superclass;
+  }
+
+  with(...mixins) {
+    return mixins.reduce(
+      (superclass, mixin) => mixin(superclass),
+      this.superclass
+    );
+  }
+}
+
+function mix(superclass) {
+  return new MixinBuilder(superclass);
+}
+
+module.exports = { mix };

--- a/lib/parser/converter/position-updater.js
+++ b/lib/parser/converter/position-updater.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const { getLineInfo } = require("acorn");
+
+const CODE = Symbol("PositionUpdater.code");
+const SET_LOCATION = Symbol("PositionUpdater.set_location()");
+
+function by_range(positionable1, positionable2) {
+  return positionable1.range[0] - positionable2.range[0];
+}
+
+function PositionUpdaterMixin(SuperClass) {
+  return class PositionUpdater extends SuperClass {
+    constructor(options) {
+      super(options);
+      this[CODE] = options.code;
+    }
+
+    [SET_LOCATION](node) {
+      if (Array.isArray(node.range) || node.loc instanceof Object) {
+        return;
+      }
+
+      const { start, end } = node;
+
+      node.range = [start, end];
+      node.loc = {
+        start: getLineInfo(this[CODE], start),
+        end: getLineInfo(this[CODE], end)
+      };
+    }
+
+    ":not(TemplateRoot, WhiteSpace):leave"(node) {
+      this[SET_LOCATION](node);
+    }
+
+    "TemplateRoot:leave"(node) {
+      const { html } = node;
+
+      html.body.sort(by_range);
+
+      html.tokens.forEach(this[SET_LOCATION], this);
+      html.tokens.sort(by_range);
+
+      html.comments.forEach(this[SET_LOCATION], this);
+      html.comments.sort(by_range);
+
+      const first_child = html.tokens[0] || { start: 0 };
+      html.start = first_child.start;
+
+      const last_child = html.tokens[html.tokens.length - 1] || {
+        end: this[CODE].length
+      };
+      html.end = last_child.end;
+
+      delete html.range;
+      delete html.loc;
+      this[SET_LOCATION](html);
+    }
+  };
+}
+
+module.exports = { PositionUpdaterMixin };

--- a/lib/parser/converter/script-block-parser.js
+++ b/lib/parser/converter/script-block-parser.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const { get_parser } = require("./espree");
+
+const CODE = Symbol("ScriptBlockParser.code");
+const PARSER_OPTIONS = Symbol("ScriptBlockParser.parser_options");
+const TOKENS = Symbol("ScriptBlockParser.tokens");
+const COMMENTS = Symbol("ScriptBlockParser.comments");
+
+function ScriptBlockParserMixin(SuperClass) {
+  return class ScriptBlockParser extends SuperClass {
+    constructor(options) {
+      super(options);
+      this[CODE] = options.code;
+      this[PARSER_OPTIONS] = options.parser_options;
+      this[TOKENS] = options.tokens;
+      this[COMMENTS] = options.comments;
+    }
+
+    "ScriptElement > .content"(node) {
+      const Parser = get_parser(node.start);
+      const program = Parser.parse(
+        this[CODE].slice(0, node.end),
+        this[PARSER_OPTIONS]
+      );
+
+      this[TOKENS].push(...program.tokens);
+      this[COMMENTS].push(...program.comments);
+      return program;
+    }
+  };
+}
+
+module.exports = { ScriptBlockParserMixin };

--- a/lib/parser/converter/tag-tokenizer.js
+++ b/lib/parser/converter/tag-tokenizer.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const { TAG_LOCATIONS } = require("./tag-locations");
+const TAG_NODE_ENTER = Object.keys(TAG_LOCATIONS).join(", ");
+
+const CODE = Symbol("TagTokenizer.code");
+const TOKENS = Symbol("TagTokenizer.tokens");
+const ADD_TOKEN = Symbol("TagTokenizer.add_token()");
+
+// eslint-disable-next-line max-lines-per-function
+function TagTokenizerMixin(SuperClass) {
+  return class TagTokenizer extends SuperClass {
+    constructor(options) {
+      super(options);
+      this[CODE] = options.code;
+      this[TOKENS] = options.tokens;
+    }
+
+    [ADD_TOKEN](index, offset, value) {
+      const start = index + offset;
+      const end = index + 1 + offset;
+
+      const actual_value = this[CODE].slice(start, end);
+      if (actual_value !== value) {
+        throw new Error(
+          `Invalid tag token range (${start}, ${end}}): Expected '${value}', got '${actual_value}'`
+        );
+      }
+
+      this[TOKENS].push({ type: "Punctuator", start, end, value });
+    }
+
+    Text(node) {
+      this[TOKENS].push({
+        type: "Text",
+        start: node.start,
+        end: node.end,
+        value: node.data
+      });
+    }
+
+    Attribute(node) {
+      this[TOKENS].push({
+        type: "Text",
+        start: node.start,
+        end: node.start + node.name.length,
+        value: node.name
+      });
+    }
+
+    [TAG_NODE_ENTER](node) {
+      const {
+        start_offset,
+        start_value,
+        end_offset,
+        end_value
+      } = TAG_LOCATIONS[node.type];
+      this[ADD_TOKEN](node.start, start_offset, start_value);
+      this[ADD_TOKEN](node.end - 1, end_offset, end_value);
+    }
+  };
+}
+
+module.exports = { TagTokenizerMixin };


### PR DESCRIPTION
- [x] Extract various domains of logic from `Converter` into separate mixins applied to `BaseVisitor` and inherited by `Converter`
- [x] Make all internal/private properties and methods use `Symbol` instances as keys to prevent any potential name conflicts across `BaseVisitor`, mixins, and `Converter`