### PR TITLE
Fix template expression and identifier parsing

### DIFF
--- a/lib/parser/converter/base-visitor.js
+++ b/lib/parser/converter/base-visitor.js
@@ -3,7 +3,7 @@
 const { replace, VisitorOption } = require("estraverse");
 const { matches, parse: parse_query } = require("esquery");
 
-const { KEYS } = require("../keys");
+const { ALL_SVELTE_KEYS } = require("../keys");
 
 const ANCESTRY = Symbol("BaseVisitor.ancestry");
 const HANDLERS = Symbol("BaseVisitor.handlers");
@@ -70,7 +70,7 @@ class BaseVisitor {
     replace(root, {
       enter: this[ENTER].bind(this),
       leave: this[LEAVE].bind(this),
-      keys: KEYS,
+      keys: ALL_SVELTE_KEYS,
       fallback: "iteration"
     });
 

--- a/lib/parser/converter/expression-parser.js
+++ b/lib/parser/converter/expression-parser.js
@@ -16,9 +16,10 @@ const EXPRESSION_NODE_ENTER = EXPRESSION_NODES.map(
   type => `${type} > .expression`
 ).join(", ");
 
-function parseExpressionAt(code, base_options, position, assignable) {
-  const Parser = get_parser(position);
-  const parser = new Parser(base_options, code);
+// eslint-disable-next-line max-params
+function parseExpressionAt(code, base_options, start, end, assignable) {
+  const Parser = get_parser(start);
+  const parser = new Parser(base_options, code.slice(0, end));
 
   parser.nextToken();
 
@@ -60,6 +61,7 @@ function ExpressionParserMixin(SuperClass) {
         this[CODE],
         this[PARSER_OPTIONS],
         node.start,
+        node.end,
         assignable
       );
 

--- a/lib/parser/converter/tag-tokenizer.js
+++ b/lib/parser/converter/tag-tokenizer.js
@@ -6,7 +6,11 @@ const {
 } = require("./template-lexer");
 
 const CODE = Symbol("TagTokenizer.code");
-const TOKENS = Symbol("TagTokenizer.tokens");
+const ESPREE_TOKENS = Symbol("TagTokenizer.espree_tokens");
+const LEXER_TOKENS = Symbol("TagTokenizer.lexer_tokens");
+const LEXER_TOKEN_INDICES = Symbol("TagTokenizer.lexer_token_indices");
+const FIND_IDENTIFIER = Symbol("TagTokenizer.find_identifier()");
+const EXPAND_IDENTIFIER = Symbol("TagTokenizer.expand_identifier()");
 
 const ESPREE_TOKEN_TYPES = {
   Identifier: "Identifier",
@@ -49,12 +53,71 @@ const TOKEN_MAPPINGS = {
   [LEXER_TOKEN_TYPES.DEBUG_START]: ESPREE_TOKEN_TYPES.Keyword
 };
 
+// eslint-disable-next-line max-lines-per-function
 function TagTokenizerMixin(SuperClass) {
   return class TagTokenizer extends SuperClass {
     constructor(options) {
       super(options);
       this[CODE] = options.code;
-      this[TOKENS] = options.tokens;
+      this[ESPREE_TOKENS] = options.tokens;
+      this[LEXER_TOKENS] = [];
+      this[LEXER_TOKEN_INDICES] = {};
+    }
+
+    [FIND_IDENTIFIER](start, type) {
+      const start_array_index = this[LEXER_TOKEN_INDICES][start];
+
+      const tokens = this[LEXER_TOKENS];
+      const mustache_start = tokens[start_array_index];
+
+      if (typeof start_array_index !== "number" || !mustache_start) {
+        throw new Error(`Could not find token for source position '${start}'`);
+      }
+
+      if (mustache_start.type !== LEXER_TOKEN_TYPES.MUSTACHE_START) {
+        throw new Error(
+          `Unexpected token '${
+            mustache_start.type
+          } for source position '${start}'`
+        );
+      }
+
+      for (let index = start_array_index; index < tokens.length; index += 1) {
+        const token = tokens[index];
+
+        if (token.type === type) {
+          return token;
+        }
+
+        if (token.type === LEXER_TOKEN_TYPES.MUSTACHE_END) {
+          break;
+        }
+      }
+
+      throw new Error(
+        `Could not find a '${type}' token for mustache tag starting at '${start}'`
+      );
+    }
+
+    [EXPAND_IDENTIFIER](node, attribute, type) {
+      const name = node[attribute];
+
+      const identifier = this[FIND_IDENTIFIER](node.start, type);
+
+      node[attribute] = {
+        type: ESPREE_TOKEN_TYPES.Identifier,
+        start: identifier.offset,
+        end: identifier.offset + identifier.value.length,
+        name: identifier.value
+      };
+
+      if (node[attribute].name !== name) {
+        throw new Error(
+          `Identifier mismatch: Expected '${name}', got '${
+            node[attribute].name
+          }'`
+        );
+      }
     }
 
     TemplateRoot() {
@@ -69,7 +132,11 @@ function TagTokenizerMixin(SuperClass) {
           throw new Error(`Unexpected token type '${type}'`);
         }
 
-        this[TOKENS].push({
+        const lexer_tokens = this[LEXER_TOKENS];
+        this[LEXER_TOKEN_INDICES][lexer_token.offset] = lexer_tokens.length;
+        lexer_tokens.push(lexer_token);
+
+        this[ESPREE_TOKENS].push({
           type,
           start: lexer_token.offset,
           end: lexer_token.offset + lexer_token.value.length,
@@ -79,7 +146,7 @@ function TagTokenizerMixin(SuperClass) {
     }
 
     Text(node) {
-      this[TOKENS].push({
+      this[ESPREE_TOKENS].push({
         type: "Text",
         start: node.start,
         end: node.end,
@@ -88,12 +155,67 @@ function TagTokenizerMixin(SuperClass) {
     }
 
     Attribute(node) {
-      this[TOKENS].push({
+      this[ESPREE_TOKENS].push({
         type: "Text",
         start: node.start,
         end: node.start + node.name.length,
         value: node.name
       });
+    }
+
+    EachBlock(node) {
+      if (node.index) {
+        this[EXPAND_IDENTIFIER](
+          node,
+          "index",
+          LEXER_TOKEN_TYPES.EACH_INDEX_IDENTIFIER
+        );
+      }
+
+      if (node.key && !node.key.type) {
+        this[EXPAND_IDENTIFIER](
+          node,
+          "key",
+          LEXER_TOKEN_TYPES.EACH_KEY_IDENTIFIER
+        );
+      }
+    }
+
+    AwaitBlock(node) {
+      if (node.pending.start === null) {
+        delete node.pending;
+      }
+
+      if (node.pending) {
+        // full await block
+        node.then.value = node.value;
+        delete node.value;
+        this[EXPAND_IDENTIFIER](
+          node.then,
+          "value",
+          LEXER_TOKEN_TYPES.AWAIT_THEN_IDENTIFIER
+        );
+      } else {
+        // compact await block
+        this[EXPAND_IDENTIFIER](
+          node,
+          "value",
+          LEXER_TOKEN_TYPES.AWAIT_THEN_IDENTIFIER
+        );
+      }
+
+      if (!node.error) {
+        delete node.catch;
+        return;
+      }
+
+      node.catch.error = node.error;
+      delete node.error;
+      this[EXPAND_IDENTIFIER](
+        node.catch,
+        "error",
+        LEXER_TOKEN_TYPES.AWAIT_CATCH_IDENTIFIER
+      );
     }
   };
 }

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -4,7 +4,7 @@ const { compile } = require("svelte/compiler");
 
 const { convert } = require("./converter");
 const { analyze } = require("./referencer");
-const { KEYS } = require("./keys");
+const { ALL_SVELTE_KEYS } = require("./keys");
 
 function compile_template(code) {
   try {
@@ -43,7 +43,7 @@ function parse(code, options) {
       js_instance,
       js_module
     },
-    visitorKeys: KEYS,
+    visitorKeys: ALL_SVELTE_KEYS,
     scopeManager
   };
 }

--- a/lib/parser/keys.js
+++ b/lib/parser/keys.js
@@ -1,11 +1,11 @@
 "use strict";
-const base_keys = require("eslint-visitor-keys");
+const base_javascript_keys = require("eslint-visitor-keys");
 
 const EXPRESSION_KEY = "expression";
 const CHILDREN_KEY = "children";
 const ELEMENT_KEYS = [CHILDREN_KEY, "attributes"];
 
-const ADDITIONAL_KEYS = {
+const BASE_TEMPLATE_KEYS = {
   TemplateRoot: ["html", "css", "instance", "module"],
 
   // fragment: root
@@ -46,13 +46,13 @@ const ADDITIONAL_KEYS = {
   Transition: [EXPRESSION_KEY],
 
   // mustache: await block
-  AwaitBlock: [EXPRESSION_KEY, "value", "pending", "then", "catch"],
+  AwaitBlock: [EXPRESSION_KEY, "pending", "then", "catch"],
   PendingBlock: [CHILDREN_KEY],
-  ThenBlock: [CHILDREN_KEY, "value"],
-  CatchBlock: [CHILDREN_KEY, "error"],
+  ThenBlock: [CHILDREN_KEY],
+  CatchBlock: [CHILDREN_KEY],
 
   // mustache: each block
-  EachBlock: [EXPRESSION_KEY, "context", "index", "key", "children", "else"],
+  EachBlock: [EXPRESSION_KEY, "key", "children", "else"],
 
   // mustache: if
   IfBlock: [EXPRESSION_KEY, CHILDREN_KEY, "else"],
@@ -69,10 +69,32 @@ const ADDITIONAL_KEYS = {
   MustacheTag: [EXPRESSION_KEY]
 };
 
-const EXPRESSION_NODES = Object.entries(ADDITIONAL_KEYS)
+const EXPRESSION_NODES = Object.entries(BASE_TEMPLATE_KEYS)
   .filter(([_type, keys]) => keys.indexOf(EXPRESSION_KEY) > -1)
   .map(([type]) => type);
 
-const KEYS = base_keys.unionWith(ADDITIONAL_KEYS);
+const BASE_SVELTE_KEYS = base_javascript_keys.unionWith(BASE_TEMPLATE_KEYS);
 
-module.exports = { KEYS, EXPRESSION_NODES };
+/**
+ * `VariableDeclaration` nodes are handled differently by `eslint-scope` than by
+ * other ESLint-related traversers: children of such declarations are not
+ * automatically recursively visited since doing so would cause duplicate
+ * references (the `eslint-scope` referencer creates initialization references
+ * for child `Identifier` nodes when visiting `VariableDeclaration` nodes).
+ *
+ * The following additional keys are for in-template declaration identifier
+ * nodes that are functionally similar to `VariableDeclaration` nodes and as
+ * such should be ignored by the extended `eslint-scope` referencer
+ * (`SvelteReferencer`).
+ */
+const ALL_TEMPLATE_KEYS = {
+  ...BASE_TEMPLATE_KEYS,
+  AwaitBlock: [...BASE_TEMPLATE_KEYS.AwaitBlock, "value"],
+  ThenBlock: [...BASE_TEMPLATE_KEYS.ThenBlock, "value"],
+  CatchBlock: [...BASE_TEMPLATE_KEYS.CatchBlock, "error"],
+  EachBlock: [...BASE_TEMPLATE_KEYS.EachBlock, "context", "index"]
+};
+
+const ALL_SVELTE_KEYS = base_javascript_keys.unionWith(ALL_TEMPLATE_KEYS);
+
+module.exports = { BASE_SVELTE_KEYS, ALL_SVELTE_KEYS, EXPRESSION_NODES };

--- a/lib/parser/keys.js
+++ b/lib/parser/keys.js
@@ -46,10 +46,10 @@ const ADDITIONAL_KEYS = {
   Transition: [EXPRESSION_KEY],
 
   // mustache: await block
-  AwaitBlock: [EXPRESSION_KEY, "value", "error", "pending", "then", "catch"],
+  AwaitBlock: [EXPRESSION_KEY, "value", "pending", "then", "catch"],
   PendingBlock: [CHILDREN_KEY],
-  ThenBlock: [CHILDREN_KEY],
-  CatchBlock: [CHILDREN_KEY],
+  ThenBlock: [CHILDREN_KEY, "value"],
+  CatchBlock: [CHILDREN_KEY, "error"],
 
   // mustache: each block
   EachBlock: [EXPRESSION_KEY, "context", "index", "key", "children", "else"],

--- a/lib/parser/referencer/index.js
+++ b/lib/parser/referencer/index.js
@@ -1,24 +1,8 @@
 "use strict";
 
 const { ScopeManager } = require("eslint-scope");
-const { KEYS } = require("../keys");
+const { BASE_SVELTE_KEYS } = require("../keys");
 const { SvelteReferencer } = require("./referencer");
-
-/**
- * Context expressions for each blocks are functionally similar to
- * `VariableDeclaration` nodes, whose children are not recursively visited by
- * `eslint-scope`; this is to prevent duplicate references for initializer
- * identifiers.
- *
- * The following excludes the `context` key from being automatically visited
- * since `EachScope` handles creating variables and referencers for context
- * expressions in much the same way as `VariableDeclaration` nodes are handled
- * by `eslint-scope`.
- */
-const visitor_keys = JSON.parse(JSON.stringify(KEYS));
-visitor_keys.EachBlock = visitor_keys.EachBlock.filter(
-  key => key !== "context"
-);
 
 // https://github.com/eslint/eslint-scope/blob/14c092a6efd4dd0bf701bf4f8f518eac6b29b2ce/lib/index.js#L61-L76
 function default_options() {
@@ -38,7 +22,7 @@ function analyze(ast, providedOptions) {
   const options = {
     ...default_options(),
     ...providedOptions,
-    childVisitorKeys: visitor_keys
+    childVisitorKeys: BASE_SVELTE_KEYS
   };
   const manager = new ScopeManager(options);
   const referencer = new SvelteReferencer(options, manager);

--- a/lib/parser/referencer/scope.js
+++ b/lib/parser/referencer/scope.js
@@ -8,9 +8,9 @@ class SvelteScope extends Scope {
     super(scopeManager, `svelte:${name}`, upperScope, block, false);
   }
 
-  __defineTemplate(name, node) {
-    const definition = new Definition(Variable.Variable, name, node);
-    this.__defineGeneric(name, this.set, this.variables, node, definition);
+  __defineTemplateIdentifier(node) {
+    const definition = new Definition(Variable.Variable, node.name, node);
+    this.__defineGeneric(node.name, this.set, this.variables, node, definition);
     this.__referencing(node, Reference.WRITE, node, null, false, true);
   }
 }
@@ -22,6 +22,10 @@ class AwaitScope extends SvelteScope {
     }
 
     super(scopeManager, "await", upperScope, block);
+
+    if (block.value) {
+      this.__defineTemplateIdentifier(block.value);
+    }
   }
 }
 
@@ -41,7 +45,9 @@ class AwaitThenScope extends SvelteScope {
 
     super(scopeManager, "await:then", upperScope, block);
 
-    this.__defineTemplate(upperScope.block.value, block);
+    if (block.value) {
+      this.__defineTemplateIdentifier(block.value);
+    }
   }
 }
 
@@ -61,7 +67,9 @@ class AwaitCatchScope extends SvelteScope {
 
     super(scopeManager, "await:catch", upperScope, block);
 
-    this.__defineTemplate(upperScope.block.error, block);
+    if (block.error) {
+      this.__defineTemplateIdentifier(block.error);
+    }
   }
 }
 
@@ -74,24 +82,21 @@ class EachScope extends SvelteScope {
     super(scopeManager, "each", upperScope, block);
 
     this.__defineContext(block.context);
-    if (block.index) {
-      this.__defineTemplate(block.index, block);
-    }
-  }
 
-  __defineIdentifier(node) {
-    this.__defineTemplate(node.name, node);
+    if (block.index) {
+      this.__defineTemplateIdentifier(block.index);
+    }
   }
 
   __defineContext(node) {
     if (node.type === "Identifier") {
-      this.__defineIdentifier(node);
+      this.__defineTemplateIdentifier(node);
     } else if (node.type === "ObjectPattern") {
       node.properties
         .map(property => property.value)
-        .forEach(this.__defineIdentifier, this);
+        .forEach(this.__defineTemplateIdentifier, this);
     } else if (node.type === "ArrayPattern") {
-      node.elements.forEach(this.__defineIdentifier, this);
+      node.elements.forEach(this.__defineTemplateIdentifier, this);
     } else {
       throw new Error(`Unexpected each block context node type '${node.type}'`);
     }


### PR DESCRIPTION
- [x] Fix parsing of each block context expressions that are followed by index declarations
- [x] Expand declaration identifiers from each and await blocks into full AST nodes
- [x] Fix each and await scopes to create references using the newly expanded AST nodes for declaration identifiers