### PR TITLE
Add compiler warnings rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,6 +40,15 @@
     "node/prefer-global/url-search-params": "error",
     "node/prefer-global/url": "error",
     "eslint-comments/no-unused-disable": "error",
-    "eslint-comments/disable-enable-pair": ["error", { "allowWholeFile": true }]
+    "eslint-comments/disable-enable-pair": [
+      "error",
+      { "allowWholeFile": true }
+    ],
+    "eslint-plugin/require-meta-docs-url": [
+      "error",
+      {
+        "pattern": "https://github.com/jarrodldavis/eslint-plugin-svelte/blob/master/docs/rules/{{name}}.md"
+      }
+    ]
   }
 }

--- a/docs/rules/compiler-warnings.md
+++ b/docs/rules/compiler-warnings.md
@@ -1,7 +1,46 @@
-# Report warnings from the Svelte compiler (warnings)
+# Report warnings from the Svelte compiler (compiler-warnings)
 
 The Svelte compiler can emit warnings while parsing templates.
-This rule allows those warnings to be presented as ESLint problems.
+
+```html
+<script>
+  export let name;
+  const posts = ["A Blog Post"];
+</script>
+
+<style>
+  h1 {
+    color: purple;
+  }
+</style>
+
+<h1>Hello {name}!</h1>
+
+{#each posts as post} {/each}
+```
+
+```sh
+$ npm run build
+
+> svelte-app@1.0.0 build /Users/jarrodldavis/source/repos/svelte-app
+> rollup -c
+
+
+src/main.js → public/bundle.js...
+(!) svelte plugin: Empty block
+src/App.svelte
+12: <h1>Hello {name}!</h1>
+13:
+14: {#each posts as post} {/each}
+    ^
+15:
+created public/bundle.js in 509ms
+```
+
+## Rule Details
+
+This rule collects warnings reported by the Svelte compiler and reports them
+as ESLint problems.
 
 ## Options
 
@@ -21,3 +60,77 @@ This rule has one option which is an object with one property.
 ### ignore
 
 An array of compiler warning codes to ignore.
+
+## Processor
+
+You can use the `@jarrodldavis/svelte/individual-warnings` plugin so that
+each warning code is reported under a separate rule ID. The main rule must still
+be enabled for any compiler warnings to be reported.
+
+Note that this is primarily a stylistic choice for how rules are reported. Due
+to how ESLint processors work, the parent rule ID _must_ be used to ignore
+individual warning codes via config files or comment directives.
+
+As such, the following **will not work**:
+
+```json
+{
+  "rules": {
+    // this doesn't work!
+    "@jarrodldavis/svelte/compiler-warnings/css-unused-selector": "off",
+    "@jarrodldavis/svelte/compiler-warnings/empty-block": "off"
+  }
+}
+```
+
+```html
+<script>
+  export let name;
+  const posts = ["A Blog Post"];
+</script>
+
+<style>
+  h1 {
+    color: purple;
+  }
+</style>
+
+<h1>Hello {name}!</h1>
+
+<!-- this doesn't work! -->
+<!-- eslint-disable-next-line @jarrodldavis/svelte/compiler-warnings/empty-block -->
+{#each posts as post} {/each}
+```
+
+Instead, use the parent rule ID:
+
+```json
+{
+  "rules": {
+    "@jarrodldavis/svelte/warnings": [
+      "warn",
+      {
+        "ignore": ["empty-block"]
+      }
+    ]
+  }
+}
+```
+
+```html
+<script>
+  export let name;
+  const posts = ["A Blog Post"];
+</script>
+
+<style>
+  h1 {
+    color: purple;
+  }
+</style>
+
+<h1>Hello {name}!</h1>
+
+<!-- eslint-disable-next-line @jarrodldavis/svelte/compiler-warnings -->
+{#each posts as post} {/each}
+```

--- a/docs/rules/compiler-warnings.md
+++ b/docs/rules/compiler-warnings.md
@@ -1,0 +1,23 @@
+# Report warnings from the Svelte compiler (warnings)
+
+The Svelte compiler can emit warnings while parsing templates.
+This rule allows those warnings to be presented as ESLint problems.
+
+## Options
+
+```json
+{
+  "@jarrodldavis/svelte/warnings": [
+    "warn",
+    {
+      "ignore": ["css-unused-selector", "empty-block"]
+    }
+  ]
+}
+```
+
+This rule has one option which is an object with one property.
+
+### ignore
+
+An array of compiler warning codes to ignore.

--- a/individual-warnings.js
+++ b/individual-warnings.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const COMPILER_WARNING_RULE_ID = "@jarrodldavis/svelte/compiler-warnings";
+
+function preprocess(text) {
+  return [text];
+}
+
+function postprocess(problems) {
+  for (const problem of problems[0]) {
+    if (problem.ruleId !== COMPILER_WARNING_RULE_ID) {
+      continue;
+    }
+
+    const [compiler_code, compiler_message] = problem.message.split(": ");
+
+    problem.ruleId += `/${compiler_code}`;
+    problem.message = compiler_message;
+  }
+
+  return problems[0];
+}
+
+module.exports = {
+  processors: {
+    ".svelte": { preprocess, postprocess }
+  }
+};

--- a/lib/configs.js
+++ b/lib/configs.js
@@ -25,6 +25,16 @@ const configs = {
     parser: "@jarrodldavis/eslint-plugin-svelte",
     plugins: ["@jarrodldavis/svelte"],
     rules: eslint_recommended_overrides
+  },
+  recommended: {
+    parser: "@jarrodldavis/eslint-plugin-svelte",
+    plugins: [
+      "@jarrodldavis/svelte",
+      "@jarrodldavis/svelte/individual-warnings"
+    ],
+    rules: {
+      "@jarrodldavis/svelte/compiler-warnings": "warn"
+    }
   }
 };
 

--- a/lib/rules/compiler-warnings.js
+++ b/lib/rules/compiler-warnings.js
@@ -1,0 +1,45 @@
+"use strict";
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "report warnings from the Svelte compiler",
+      category: "Possible Errors",
+      recommended: true
+    },
+    schema: [
+      {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          ignore: {
+            type: "array",
+            uniqueItems: true,
+            items: { type: "string" }
+          }
+        }
+      }
+    ]
+  },
+  create(context) {
+    const {
+      options: [{ ignore }],
+      parserServices: { warnings }
+    } = context;
+
+    for (const warning of warnings) {
+      if (ignore.indexOf(warning.code) > -1) {
+        continue;
+      }
+
+      context.report({
+        message: "{{ code }}: {{ message }}",
+        data: warning,
+        loc: warning
+      });
+    }
+
+    return {};
+  }
+};

--- a/lib/rules/compiler-warnings.js
+++ b/lib/rules/compiler-warnings.js
@@ -6,7 +6,9 @@ module.exports = {
     docs: {
       description: "report warnings from the Svelte compiler",
       category: "Possible Errors",
-      recommended: true
+      recommended: true,
+      url:
+        "https://github.com/jarrodldavis/eslint-plugin-svelte/blob/master/docs/rules/compiler-warnings.md"
     },
     schema: [
       {

--- a/lib/rules/compiler-warnings.js
+++ b/lib/rules/compiler-warnings.js
@@ -26,12 +26,12 @@ module.exports = {
   },
   create(context) {
     const {
-      options: [{ ignore }],
+      options: [{ ignore } = {}],
       parserServices: { warnings }
     } = context;
 
     for (const warning of warnings) {
-      if (ignore.indexOf(warning.code) > -1) {
+      if (ignore && ignore.indexOf(warning.code) > -1) {
         continue;
       }
 

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -3,6 +3,7 @@
 
 module.exports = {
   rules: {
+    "compiler-warnings": require("./compiler-warnings"),
     indent: require("./indent"),
     "no-labels": require("./no-labels"),
     "no-unused-labels": require("./no-unused-labels")


### PR DESCRIPTION
- [x] Add `compiler-warnings` rule that reports Svelte compiler warnings as ESLint problems
- [x] Add ESLint processor that transforms those reproted problems into individual sub-rule problems
- [x] Add documentation for the new rule