### PR TITLE
Add support for HTML comments

### DIFF
--- a/lib/parser/converter/converter.js
+++ b/lib/parser/converter/converter.js
@@ -53,6 +53,15 @@ class Converter extends MixedInVisitor {
     }
   }
 
+  Comment(node) {
+    this[COMMENTS].push({
+      type: "Block",
+      value: node.data,
+      start: node.start,
+      end: node.end
+    });
+  }
+
   WhiteSpace() {
     return VisitorOption.Remove;
   }

--- a/lib/parser/converter/template-lexer.js
+++ b/lib/parser/converter/template-lexer.js
@@ -51,6 +51,7 @@ const template_lexer = moo.states({
       lineBreaks: true,
       push: "style_block"
     },
+    _comment_start: { match: /<!--/, push: "comment" },
     [TOKENS.HTML_OPEN_START]: { match: /<(?!\/)/, push: "html_open" },
     [TOKENS.HTML_CLOSE_START]: { match: /<\//, push: "html_close" },
     [TOKENS.MUSTACHE_START]: { match: /{/, lineBreaks: true, push: "mustache" }
@@ -66,6 +67,10 @@ const template_lexer = moo.states({
   style_block: {
     _style_body: { match: /[\s\S]+?(?=<\/\s*style[^>]*>)/, lineBreaks: true },
     _end_style_tag: { match: /<\/\s*style[^>]*>/, lineBreaks: true, pop: true }
+  },
+  comment: {
+    _comment_contents: { match: /(?:(?!-->)[\s\S])+/, lineBreaks: true },
+    _comment_end: { match: /-->/, pop: true }
   },
   html_open: {
     _html_open_contents: { match: /[^{>]+/, lineBreaks: true },


### PR DESCRIPTION
- [x] Update the template lexer to ignore comments instead of treating them like HTML tags
- [x] Convert Svelte-provided `Comment` nodes into Espree comments so that ESLint enable/disable directives are supported