### PR TITLE
Update parse errors

### DIFF
--- a/lib/parser/converter/base-visitor.js
+++ b/lib/parser/converter/base-visitor.js
@@ -4,9 +4,11 @@ const { replace, VisitorOption } = require("estraverse");
 const { matches, parse: parse_query } = require("esquery");
 
 const { ALL_SVELTE_KEYS } = require("../keys");
+const { POSITION_APPLIED, apply_node_position } = require("../errors");
 
 const ANCESTRY = Symbol("BaseVisitor.ancestry");
 const HANDLERS = Symbol("BaseVisitor.handlers");
+const CODE = Symbol("BaseVisitor.code");
 const ENTER = Symbol("BaseVisitor.enter()");
 const LEAVE = Symbol("BaseVisitor.leave()");
 const HANDLER_LOOP = Symbol("BaseVisitor.handler_loop()");
@@ -51,13 +53,14 @@ function compile_handlers(visitor) {
 }
 
 class BaseVisitor {
-  constructor() {
+  constructor({ code }) {
     if (Object.getPrototypeOf(this) === BaseVisitor.prototype) {
       throw new Error("BaseVisitor must be subclassed to be instantiated");
     }
 
     this[ANCESTRY] = [];
     this[HANDLERS] = compile_handlers(this);
+    this[CODE] = code;
 
     if (this[HANDLERS].length === 0) {
       throw new Error(
@@ -139,7 +142,15 @@ class BaseVisitor {
       return null;
     }
 
-    return handler.handler(node);
+    try {
+      return handler.handler(node);
+    } catch (error) {
+      if (!error[POSITION_APPLIED]) {
+        apply_node_position(error, node, this[CODE]);
+      }
+
+      throw error;
+    }
   }
 }
 

--- a/lib/parser/converter/converter.js
+++ b/lib/parser/converter/converter.js
@@ -2,6 +2,8 @@
 
 const { VisitorOption } = require("estraverse");
 
+const { NodeSyntaxError } = require("../errors");
+
 const { BaseVisitor } = require("./base-visitor");
 const { mix } = require("./helpers/mixin-builder");
 const { ExpressionParserMixin } = require("./expression-parser");
@@ -34,7 +36,11 @@ class Converter extends MixedInVisitor {
 
   "*"(node) {
     if (node[TRAVERSAL_MARKER] === true) {
-      throw new Error("Node has already been traversed");
+      throw new NodeSyntaxError(
+        node,
+        "Node has already been traversed",
+        this[CODE]
+      );
     }
 
     node[TRAVERSAL_MARKER] = true;

--- a/lib/parser/converter/expression-parser.js
+++ b/lib/parser/converter/expression-parser.js
@@ -1,6 +1,8 @@
 "use strict";
 
-const { parseExpressionAt } = require("./helpers//espree");
+const { NodeSyntaxError } = require("../errors");
+
+const { parseExpressionAt } = require("./helpers/espree");
 const { EXPRESSION_NODES } = require("../keys");
 
 const CODE = Symbol("ExpressionParser.code");
@@ -34,10 +36,12 @@ function ExpressionParserMixin(SuperClass) {
       );
 
       if (expression.type !== node.type) {
-        throw new Error(
+        throw new NodeSyntaxError(
+          node,
           `Parse result mismatch for template expression: expected '${
             node.type
-          }', got '${expression.type}'`
+          }', got '${expression.type}'`,
+          this[CODE]
         );
       }
 
@@ -73,8 +77,10 @@ function ExpressionParserMixin(SuperClass) {
         case "ArrayPattern":
           break;
         default:
-          throw new Error(
-            `Unexpected let directive expression type '${node.type}'`
+          throw new NodeSyntaxError(
+            node,
+            `Unexpected let directive expression type '${node.type}'`,
+            this[CODE]
           );
       }
 

--- a/lib/parser/converter/helpers/template-lexer.js
+++ b/lib/parser/converter/helpers/template-lexer.js
@@ -6,6 +6,7 @@ const moo = require("moo");
 const { LEXER_TOKEN_TYPES: TOKENS } = require("./token-mappings");
 
 const template_lexer = moo.states({
+  $all: { error: moo.error },
   main: {
     _body: { match: /[^<{]+/, lineBreaks: true },
     _script_start_tag: {
@@ -421,4 +422,4 @@ const template_lexer = moo.states({
   }
 });
 
-module.exports = { template_lexer, TOKEN_TYPES: TOKENS };
+module.exports = { template_lexer };

--- a/lib/parser/converter/tag-tokenizer.js
+++ b/lib/parser/converter/tag-tokenizer.js
@@ -2,6 +2,8 @@
 
 const { VisitorOption } = require("estraverse");
 
+const { LexerTokenSyntaxError, NodeSyntaxError } = require("../errors");
+
 const { template_lexer } = require("./helpers/template-lexer");
 
 const {
@@ -28,24 +30,30 @@ function TagTokenizerMixin(SuperClass) {
       this[IDENTIFIER_TOKENS] = [];
     }
 
-    [GET_IDENTIFIER](type, name) {
+    [GET_IDENTIFIER](node, property, type) {
       const identifier = this[IDENTIFIER_TOKENS].shift();
 
       if (!identifier) {
-        throw new Error("Could not get identifier token");
+        throw new NodeSyntaxError(
+          node,
+          `Could not get '${type}' token`,
+          this[CODE]
+        );
       }
 
       if (identifier.type !== type) {
-        throw new Error(
+        throw new LexerTokenSyntaxError(
+          identifier,
           `Identifier type mismatch: Expected '${type}', got '${
             identifier.type
           }'`
         );
       }
 
-      if (identifier.value !== name) {
-        throw new Error(
-          `Identifier name mismatch: Expected '${name}', got '${
+      if (identifier.value !== node[property]) {
+        throw new LexerTokenSyntaxError(
+          identifier,
+          `Identifier name mismatch: Expected '${node[property]}', got '${
             identifier.value
           }'`
         );
@@ -54,12 +62,10 @@ function TagTokenizerMixin(SuperClass) {
       return identifier;
     }
 
-    [EXPAND_IDENTIFIER](node, attribute, type) {
-      const name = node[attribute];
+    [EXPAND_IDENTIFIER](node, property, type) {
+      const identifier = this[GET_IDENTIFIER](node, property, type);
 
-      const identifier = this[GET_IDENTIFIER](type, name);
-
-      node[attribute] = {
+      node[property] = {
         type: ESPREE_TOKEN_TYPES.Identifier,
         start: identifier.offset,
         end: identifier.offset + identifier.value.length,
@@ -81,9 +87,16 @@ function TagTokenizerMixin(SuperClass) {
           continue;
         }
 
+        if (lexer_token.type === "error") {
+          throw new LexerTokenSyntaxError(lexer_token, "Unexpected token");
+        }
+
         const type = TOKEN_MAPPINGS[lexer_token.type];
         if (!type) {
-          throw new Error(`Unexpected token type '${lexer_token.type}'`);
+          throw new LexerTokenSyntaxError(
+            lexer_token,
+            `Unexpected token type '${lexer_token.type}'`
+          );
         }
 
         if (type === ESPREE_TOKEN_TYPES.Identifier) {
@@ -129,7 +142,11 @@ function TagTokenizerMixin(SuperClass) {
        */
       if (node.type === "Let" && node.expression) {
         // update token array so that identifier token is discarded
-        this[GET_IDENTIFIER](LEXER_TOKEN_TYPES.DIRECTIVE_IDENTIFIER, node.name);
+        this[GET_IDENTIFIER](
+          node,
+          "name",
+          LEXER_TOKEN_TYPES.DIRECTIVE_IDENTIFIER
+        );
         return;
       }
 
@@ -142,8 +159,9 @@ function TagTokenizerMixin(SuperClass) {
 
     "Binding, Class, EventHandler"(node) {
       const lexer_token = this[GET_IDENTIFIER](
-        LEXER_TOKEN_TYPES.DIRECTIVE_IDENTIFIER,
-        node.name
+        node,
+        "name",
+        LEXER_TOKEN_TYPES.DIRECTIVE_IDENTIFIER
       );
 
       if (

--- a/lib/parser/errors.js
+++ b/lib/parser/errors.js
@@ -1,0 +1,52 @@
+// eslint-disable-next-line max-classes-per-file
+"use strict";
+
+const { getLineInfo } = require("acorn");
+
+const POSITION_APPLIED = Symbol("eslint-plugin-svelte error position marker");
+
+class LexerTokenSyntaxError extends SyntaxError {
+  constructor(lexer_token, message) {
+    super(message);
+    this.lineNumber = lexer_token.line;
+    this.column = lexer_token.col;
+    this.index = lexer_token.offset;
+    this[POSITION_APPLIED] = true;
+  }
+}
+
+function apply_node_position(error, node, code) {
+  error[POSITION_APPLIED] = true;
+
+  error.index = node.start;
+
+  if (node.loc && node.loc.start) {
+    error.lineNumber = node.loc.start.line;
+    // ESLint expects errors to have 1-based columns
+    error.column = node.loc.start.column + 1;
+    return;
+  }
+
+  if (!code) {
+    return;
+  }
+
+  const { line, column } = getLineInfo(code, node.start);
+  error.lineNumber = line;
+  // ESLint expects errors to have 1-based columns
+  error.column = column + 1;
+}
+
+class NodeSyntaxError extends SyntaxError {
+  constructor(node, message, code = null) {
+    super(message);
+    apply_node_position(this, node, code);
+  }
+}
+
+module.exports = {
+  POSITION_APPLIED,
+  LexerTokenSyntaxError,
+  apply_node_position,
+  NodeSyntaxError
+};

--- a/lib/parser/referencer/referencer.js
+++ b/lib/parser/referencer/referencer.js
@@ -1,5 +1,8 @@
 /* eslint-disable new-cap */
 "use strict";
+
+const { NodeSyntaxError } = require("../errors");
+
 const { Variable } = require("eslint-scope");
 const Referencer = require("eslint-scope/lib/referencer");
 const { Definition } = require("eslint-scope/lib/definition");
@@ -20,8 +23,11 @@ class SvelteReferencer extends Referencer {
     this.visitPattern(node, { processRightHandNodes: true }, handle_identifier);
   }
 
-  Fragment() {
-    throw new Error("Fragment nodes should be converted to Program nodes");
+  Fragment(node) {
+    throw new NodeSyntaxError(
+      node,
+      "Fragment nodes should be converted to Program nodes"
+    );
   }
 
   AwaitBlock(node) {
@@ -101,13 +107,10 @@ class SvelteReferencer extends Referencer {
   Let(node) {
     const scope = this.currentScope();
 
-    if (scope.type !== "block") {
-      throw new Error(`Expected block scope, got '${scope.type}'`);
-    }
-
-    if (scope.block.type !== "InlineComponent") {
-      throw new Error(
-        `Expected scope for InlineComponet, got scope for '${scope.block.type}'`
+    if (scope.type !== "block" || scope.block.type !== "InlineComponent") {
+      throw new NodeSyntaxError(
+        node,
+        "Unexpected let directive for non-component tag"
       );
     }
 
@@ -116,7 +119,8 @@ class SvelteReferencer extends Referencer {
     } else if (node.name) {
       this.visitTemplateDeclaration(node.name, node);
     } else {
-      throw new Error(
+      throw new NodeSyntaxError(
+        node,
         "Expected let directive to contain a declaration identifier"
       );
     }


### PR DESCRIPTION
Update thrown parse errors to provide location information (when applicable) to ESLint so it can point to the invalid section of code.