### PR TITLE
Fix various parser and rule issues

### DIFF
--- a/lib/parser/converter/converter.js
+++ b/lib/parser/converter/converter.js
@@ -50,12 +50,19 @@ class Converter extends MixedInVisitor {
   Property(node) {
     if (node.key === node.value) {
       delete node.value;
+    } else if (
+      node.value.type === "AssignmentPattern" &&
+      node.key === node.value.left
+    ) {
+      delete node.value.left;
     }
   }
 
   "Property:leave"(node) {
     if (!node.value) {
       node.value = node.key;
+    } else if (node.value.type === "AssignmentPattern" && !node.value.left) {
+      node.value.left = node.key;
     }
   }
 

--- a/lib/parser/converter/expression-parser.js
+++ b/lib/parser/converter/expression-parser.js
@@ -72,7 +72,7 @@ function ExpressionParserMixin(SuperClass) {
         case "ArrayExpression":
           node.type = "ArrayPattern";
           break;
-        case "Identfier":
+        case "Identifier":
         case "ObjectPattern":
         case "ArrayPattern":
           break;

--- a/lib/parser/converter/helpers/template-lexer.js
+++ b/lib/parser/converter/helpers/template-lexer.js
@@ -191,7 +191,7 @@ const template_lexer = moo.states({
     [TOKENS.ATTRIBUTE_DOUBLE_QUOTE]: { match: /(?<!\\)"/, pop: true }
   },
   html_attribute_single_string: {
-    [TOKENS.ATTRIBUTE_VALUE]: { match: /[^']+/, lineBreaks: true },
+    [TOKENS.ATTRIBUTE_VALUE]: { match: /[^'{}]+/, lineBreaks: true },
     [TOKENS.MUSTACHE_START]: { match: /{/, push: "mustache" },
     /**
      * Currently, the Svelte compiler doesn't throw a parse error on unexpected
@@ -205,8 +205,12 @@ const template_lexer = moo.states({
     [TOKENS.ATTRIBUTE_SINGLE_QUOTE]: { match: /(?<!\\)'/, pop: true }
   },
   html_close: {
-    _html_close_contents: { match: /[^>]+/, lineBreaks: true },
+    [TOKENS.HTML_TAG_NAME]: { match: /[^\s>]+/, push: "html_close_whitespace" },
     [TOKENS.HTML_CLOSE_END]: { match: />/, pop: true }
+  },
+  html_close_whitespace: {
+    _whitespace: { match: /\s+/, lineBreaks: true },
+    _html_close_end: { match: /(?=>)/, pop: true }
   },
   mustache: {
     _whitespace: { match: /(?<!})\s+/, lineBreaks: true },

--- a/lib/parser/converter/tag-tokenizer.js
+++ b/lib/parser/converter/tag-tokenizer.js
@@ -41,6 +41,18 @@ function TagTokenizerMixin(SuperClass) {
         );
       }
 
+      if (identifier.offset < node.start || identifier.offset > node.end) {
+        throw new NodeSyntaxError(
+          node,
+          `Identifier position mismatch: Expected token in index range [${
+            node.start
+          }, ${node.end}], got index ${identifier.offset} (${identifier.line}:${
+            identifier.col
+          })`,
+          this[CODE]
+        );
+      }
+
       if (identifier.type !== type) {
         throw new LexerTokenSyntaxError(
           identifier,
@@ -111,6 +123,30 @@ function TagTokenizerMixin(SuperClass) {
           value: lexer_token.value
         });
       }
+    }
+
+    Attribute(node) {
+      const colon_index = node.name.indexOf(":");
+      if (colon_index === -1) {
+        return;
+      }
+
+      node._lexer_token_name = node.name.slice(colon_index + 1);
+
+      const lexer_token = this[GET_IDENTIFIER](
+        node,
+        "_lexer_token_name",
+        LEXER_TOKEN_TYPES.DIRECTIVE_IDENTIFIER
+      );
+
+      delete node._lexer_token_name;
+
+      this[ESPREE_TOKENS].push({
+        type: "String",
+        start: lexer_token.offset,
+        end: lexer_token.offset + lexer_token.value.length,
+        value: lexer_token.value
+      });
     }
 
     "Attribute > Text"() {

--- a/lib/rules/no-labels.js
+++ b/lib/rules/no-labels.js
@@ -6,6 +6,10 @@ const composer = require("eslint-rule-composer");
 const base_rule = new Linter().getRules().get("no-labels");
 
 module.exports = composer.filterReports(base_rule, problem => {
+  if (problem.node.type === "BreakStatement") {
+    return true;
+  }
+
   if (problem.node.type !== "LabeledStatement") {
     throw new Error(`Unexpected node type '${problem.node.type}'`);
   }


### PR DESCRIPTION
- [x] Fix duplicate traversal of object patterns with default values e.g. `function({ option = "default value" }) { console.log(option); }`
- [x] Fix typo when looking for Identifier let directive expressions
- [x] Check for token position mismatch when retrieving template identifiers
- [x] Fix tokenization of mustache tags in single-quoted HTML attribute values
- [x] Handle `BreakStatement` nodes in the `no-labels` rule override since the base rule also reports unexpected `break <label>;` statements.
- [x] Improve tokenization of closing HTML tags include the tag name as a tokenizer-emitted (Espree formatted) token
- [x] Fix tokenization of non-directive attribute names that contain colons