### PR TITLE
Establish baselines for template lexer

### DIFF
--- a/test/baselines/template-lexer/01.angle-bracket-tags/01.block-tags/01.empty-pair.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/01.block-tags/01.empty-pair.svelte.json
@@ -1,0 +1,83 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 11,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 12
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/01.block-tags/02.pair-with-plain-content.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/01.block-tags/02.pair-with-plain-content.svelte.json
@@ -1,0 +1,92 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 15,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 16
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/01.block-tags/03.pair-with-mustache-content.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/01.block-tags/03.pair-with-mustache-content.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"some value\";\n",
+    "text": "\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 48,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 68,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 19
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/01.block-tags/04.pair-with-mixed-content.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/01.block-tags/04.pair-with-mixed-content.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"some value\";\n",
+    "text": "\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 48,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Text: ",
+    "text": "Text: ",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/01.block-tags/05.self-closing.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/01.block-tags/05.self-closing.svelte.json
@@ -1,0 +1,56 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 7,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/02.void-tags/01.closing-slash.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/02.void-tags/01.closing-slash.svelte.json
@@ -1,0 +1,56 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 9,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/02.void-tags/02.no-closing-slash.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/02.void-tags/02.no-closing-slash.svelte.json
@@ -1,0 +1,47 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 7,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/03.components/01.empty-pair.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/03.components/01.empty-pair.svelte.json
@@ -1,0 +1,119 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 60,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 12
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/03.components/02.pair-with-plain-content.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/03.components/02.pair-with-plain-content.svelte.json
@@ -1,0 +1,128 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 64,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 16
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/03.components/03.pair-with-mustache-content.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/03.components/03.pair-with-mustache-content.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const value = \"some value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 78,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 98,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 19
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/03.components/04.pair-with-mixed-content.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/03.components/04.pair-with-mixed-content.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const value = \"some value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 78,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Text: ",
+    "text": "Text: ",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 104,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/03.components/05.self-closing.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/03.components/05.self-closing.svelte.json
@@ -1,0 +1,92 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 56,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/01.simple/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/01.simple/01.unquoted.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 22,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/01.simple/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/01.simple/02.double-quoted.svelte.json
@@ -1,0 +1,182 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 24,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/01.simple/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/01.simple/03.single-quoted.svelte.json
@@ -1,0 +1,182 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 24,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/01.simple/04.boolean.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/01.simple/04.boolean.svelte.json
@@ -1,0 +1,137 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "hidden",
+    "text": "hidden",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 18,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 19
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/02.hyphen/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/02.hyphen/01.unquoted.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 27,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/02.hyphen/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/02.hyphen/02.double-quoted.svelte.json
@@ -1,0 +1,182 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 29,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/02.hyphen/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/02.hyphen/03.single-quoted.svelte.json
@@ -1,0 +1,182 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 29,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/02.hyphen/04.boolean.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/02.hyphen/04.boolean.svelte.json
@@ -1,0 +1,137 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-hidden",
+    "text": "data-hidden",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 23,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/03.colon/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/03.colon/01.unquoted.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 25,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/03.colon/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/03.colon/02.double-quoted.svelte.json
@@ -1,0 +1,209 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 27,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/03.colon/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/03.colon/03.single-quoted.svelte.json
@@ -1,0 +1,209 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 27,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/03.colon/04.boolean.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/01.block-tags/03.colon/04.boolean.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "hidden",
+    "text": "hidden",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 21,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/01.simple/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/01.simple/01.unquoted.svelte.json
@@ -1,0 +1,137 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 20,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/01.simple/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/01.simple/02.double-quoted.svelte.json
@@ -1,0 +1,155 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 22,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/01.simple/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/01.simple/03.single-quoted.svelte.json
@@ -1,0 +1,155 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 22,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/01.simple/04.boolean.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/01.simple/04.boolean.svelte.json
@@ -1,0 +1,110 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "disabled",
+    "text": "disabled",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 18,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 19
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/02.hyphen/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/02.hyphen/01.unquoted.svelte.json
@@ -1,0 +1,137 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 25,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/02.hyphen/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/02.hyphen/02.double-quoted.svelte.json
@@ -1,0 +1,155 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 27,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/02.hyphen/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/02.hyphen/03.single-quoted.svelte.json
@@ -1,0 +1,155 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 27,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/02.hyphen/04.boolean.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/02.hyphen/04.boolean.svelte.json
@@ -1,0 +1,110 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-disabled",
+    "text": "data-disabled",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 23,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/03.colon/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/03.colon/01.unquoted.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 23,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/03.colon/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/03.colon/02.double-quoted.svelte.json
@@ -1,0 +1,182 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 25,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/03.colon/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/03.colon/03.single-quoted.svelte.json
@@ -1,0 +1,182 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "some_id",
+    "text": "some_id",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 25,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/03.colon/04.boolean.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/02.void-tags/03.colon/04.boolean.svelte.json
@@ -1,0 +1,137 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "disabled",
+    "text": "disabled",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 21,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/01.simple/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/01.simple/01.unquoted.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "prop",
+    "text": "prop",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 71,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/01.simple/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/01.simple/02.double-quoted.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "prop",
+    "text": "prop",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 73,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/01.simple/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/01.simple/03.single-quoted.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "prop",
+    "text": "prop",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 73,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/01.simple/04.boolean.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/01.simple/04.boolean.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "prop",
+    "text": "prop",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 65,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/02.hyphen/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/02.hyphen/01.unquoted.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-prop",
+    "text": "data-prop",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/02.hyphen/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/02.hyphen/02.double-quoted.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-prop",
+    "text": "data-prop",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 78,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/02.hyphen/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/02.hyphen/03.single-quoted.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-prop",
+    "text": "data-prop",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 78,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/02.hyphen/04.boolean.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/02.hyphen/04.boolean.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-prop",
+    "text": "data-prop",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 70,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/03.colon/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/03.colon/01.unquoted.svelte.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "prop",
+    "text": "prop",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/03.colon/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/03.colon/02.double-quoted.svelte.json
@@ -1,0 +1,245 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "prop",
+    "text": "prop",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/03.colon/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/03.colon/03.single-quoted.svelte.json
@@ -1,0 +1,245 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "prop",
+    "text": "prop",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/03.colon/04.boolean.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/04.plain-attributes/03.components/03.colon/04.boolean.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "prop",
+    "text": "prop",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 68,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 20
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/01.simple/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/01.simple/01.unquoted.svelte.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 63,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 20
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/01.simple/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/01.simple/02.double-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 65,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/01.simple/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/01.simple/03.single-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 65,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/02.hyphen/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/02.hyphen/01.unquoted.svelte.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 68,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/02.hyphen/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/02.hyphen/02.double-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 70,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 27
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/02.hyphen/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/02.hyphen/03.single-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 70,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 27
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/03.colon/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/03.colon/01.unquoted.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 66,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/03.colon/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/03.colon/02.double-quoted.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 68,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/03.colon/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/03.colon/03.single-quoted.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 68,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/04.miscellaneous/01.shorthand.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/04.miscellaneous/01.shorthand.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 60,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/04.miscellaneous/02.spread.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/01.block-tags/04.miscellaneous/02.spread.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const props = {\"id\": \"some_id\"};\n",
+    "text": "\n  const props = {\"id\": \"some_id\"};\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 53,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "...props",
+    "text": "...props",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 77,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/01.simple/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/01.simple/01.unquoted.svelte.json
@@ -1,0 +1,209 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 61,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 18
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/01.simple/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/01.simple/02.double-quoted.svelte.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 63,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 20
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/01.simple/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/01.simple/03.single-quoted.svelte.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 63,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 20
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/02.hyphen/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/02.hyphen/01.unquoted.svelte.json
@@ -1,0 +1,209 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 66,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/02.hyphen/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/02.hyphen/02.double-quoted.svelte.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 68,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/02.hyphen/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/02.hyphen/03.single-quoted.svelte.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-id",
+    "text": "data-id",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 68,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/03.colon/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/03.colon/01.unquoted.svelte.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"script_id\";\n",
+    "text": "\n  const id = \"script_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 44,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 66,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/03.colon/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/03.colon/02.double-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 66,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/03.colon/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/03.colon/03.single-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 66,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/04.miscellaneous/01.shorthand.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/04.miscellaneous/01.shorthand.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const id = \"some_id\";\n",
+    "text": "\n  const id = \"some_id\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 58,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 15
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/04.miscellaneous/02.spread.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/02.void-tags/04.miscellaneous/02.spread.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const props = {\"id\": \"some_id\"};\n",
+    "text": "\n  const props = {\"id\": \"some_id\"};\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 53,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "...props",
+    "text": "...props",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 75,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/01.simple/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/01.simple/01.unquoted.svelte.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "prop",
+    "text": "prop",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "prop",
+    "text": "prop",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 97,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/01.simple/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/01.simple/02.double-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "prop",
+    "text": "prop",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "prop",
+    "text": "prop",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/01.simple/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/01.simple/03.single-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "prop",
+    "text": "prop",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "prop",
+    "text": "prop",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/02.hyphen/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/02.hyphen/01.unquoted.svelte.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-prop",
+    "text": "data-prop",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "prop",
+    "text": "prop",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 29
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/02.hyphen/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/02.hyphen/02.double-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-prop",
+    "text": "data-prop",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "prop",
+    "text": "prop",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 104,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 31
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/02.hyphen/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/02.hyphen/03.single-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "data-prop",
+    "text": "data-prop",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "prop",
+    "text": "prop",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 104,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 31
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/03.colon/01.unquoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/03.colon/01.unquoted.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "prop",
+    "text": "prop",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "prop",
+    "text": "prop",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 100,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 27
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/03.colon/02.double-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/03.colon/02.double-quoted.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "prop",
+    "text": "prop",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "prop",
+    "text": "prop",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 29
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/03.colon/03.single-quoted.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/03.colon/03.single-quoted.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "ns",
+    "text": "ns",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "prop",
+    "text": "prop",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "prop",
+    "text": "prop",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 29
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/04.miscellaneous/01.shorthand.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/04.miscellaneous/01.shorthand.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "prop",
+    "text": "prop",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 92,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 19
+  }
+]

--- a/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/04.miscellaneous/02.spread.svelte.json
+++ b/test/baselines/template-lexer/01.angle-bracket-tags/05.mustache-attributes/03.components/04.miscellaneous/02.spread.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const props = {\"id\": \"some_id\"};\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const props = {\"id\": \"some_id\"};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 83,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "...props",
+    "text": "...props",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 107,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/02.at-tags/01.raw-html/01.single-identifier.svelte.json
+++ b/test/baselines/template-lexer/02.at-tags/01.raw-html/01.single-identifier.svelte.json
@@ -1,0 +1,92 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const html = \"<div>Text</div>\";\n",
+    "text": "\n  const html = \"<div>Text</div>\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 52,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "raw_html_start",
+    "value": "@html",
+    "text": "@html",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_raw_html_expression",
+    "value": " html",
+    "text": " html",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 66,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 13
+  }
+]

--- a/test/baselines/template-lexer/02.at-tags/01.raw-html/02.binary-expression.svelte.json
+++ b/test/baselines/template-lexer/02.at-tags/01.raw-html/02.binary-expression.svelte.json
@@ -1,0 +1,92 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const html = \"<div>Text</div>\",\n    html2 = \"<p>More Text</p>\";\n",
+    "text": "\n  const html = \"<div>Text</div>\",\n    html2 = \"<p>More Text</p>\";\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 84,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "raw_html_start",
+    "value": "@html",
+    "text": "@html",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_raw_html_expression",
+    "value": " html + html2",
+    "text": " html + html2",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 106,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/02.at-tags/01.raw-html/03.template-expression.svelte.json
+++ b/test/baselines/template-lexer/02.at-tags/01.raw-html/03.template-expression.svelte.json
@@ -1,0 +1,128 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"some_value\";\n",
+    "text": "\n  const value = \"some_value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 48,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "raw_html_start",
+    "value": "@html",
+    "text": "@html",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_raw_html_expression",
+    "value": " `<div>$",
+    "text": " `<div>$",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_brace_contents",
+    "value": "value",
+    "text": "value",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_raw_html_expression",
+    "value": "</div>`",
+    "text": "</div>`",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 79,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/02.at-tags/02.debug/01.single-identifier.svelte.json
+++ b/test/baselines/template-lexer/02.at-tags/02.debug/01.single-identifier.svelte.json
@@ -1,0 +1,92 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const active = \"active\";\n",
+    "text": "\n  const active = \"active\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 45,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "debug_start",
+    "value": "@debug",
+    "text": "@debug",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_debug_identifiers",
+    "value": " active",
+    "text": " active",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 62,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 16
+  }
+]

--- a/test/baselines/template-lexer/02.at-tags/02.debug/02.multiple-identifiers.svelte.json
+++ b/test/baselines/template-lexer/02.at-tags/02.debug/02.multiple-identifiers.svelte.json
@@ -1,0 +1,92 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const active = \"active\",\n    checked = true,\n    id = \"some_id\",\n    number = 1;\n",
+    "text": "\n  const active = \"active\",\n    checked = true,\n    id = \"some_id\",\n    number = 1;\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 101,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "debug_start",
+    "value": "@debug",
+    "text": "@debug",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_debug_identifiers",
+    "value": " active, checked, id, number",
+    "text": " active, checked, id, number",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 139,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/03.if/01.if.svelte.json
+++ b/test/baselines/template-lexer/03.if/01.if.svelte.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 80,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/02.if-else.svelte.json
+++ b/test/baselines/template-lexer/03.if/02.if-else.svelte.json
@@ -1,0 +1,362 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Disabled",
+    "text": "Disabled",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 100,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 106,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/03.if-else-if.svelte.json
+++ b/test/baselines/template-lexer/03.if/03.if-else-if.svelte.json
@@ -1,0 +1,407 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const random = Math.random(),\n    zero = 0;\n",
+    "text": "\n  const random = Math.random(),\n    zero = 0;\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 85,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Positive",
+    "text": "Positive",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 103,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "random < zero",
+    "text": "random < zero",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 128,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Negative",
+    "text": "Negative",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 152,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/04.if-else-if-else.svelte.json
+++ b/test/baselines/template-lexer/03.if/04.if-else-if-else.svelte.json
@@ -1,0 +1,542 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const random = Math.random(),\n    zero = 0;\n",
+    "text": "\n  const random = Math.random(),\n    zero = 0;\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 85,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Positive",
+    "text": "Positive",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 103,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "random < zero",
+    "text": "random < zero",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 128,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Negative",
+    "text": "Negative",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 154,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Zero",
+    "text": "Zero",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 10
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 12
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 13
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 13
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 168,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 174,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/05.if-nested-[if].svelte.json
+++ b/test/baselines/template-lexer/03.if/05.if-nested-[if].svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "text": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 84,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 121,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Enabled, Positive",
+    "text": "Enabled, Positive",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 150,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 158,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 164,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/06.if-else-nested-[if].svelte.json
+++ b/test/baselines/template-lexer/03.if/06.if-else-nested-[if].svelte.json
@@ -1,0 +1,461 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "text": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 84,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 116,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Positive",
+    "text": "Disabled, Positive",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 176,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 184,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 190,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/07.if-else-nested-[if-else].svelte.json
+++ b/test/baselines/template-lexer/03.if/07.if-else-nested-[if-else].svelte.json
@@ -1,0 +1,596 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "text": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 84,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 116,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Positive",
+    "text": "Disabled, Positive",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 176,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 186,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Not Positive",
+    "text": "Disabled, Not Positive",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 218,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 219,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 33
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 219,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 220,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 34
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 223,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 224,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 227,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 228,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 228,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 229,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 230,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 234,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 234,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/08.if-else-nested-[if-else-if].svelte.json
+++ b/test/baselines/template-lexer/03.if/08.if-else-nested-[if-else-if].svelte.json
@@ -1,0 +1,641 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "text": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 84,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 116,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Positive",
+    "text": "Disabled, Positive",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 176,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 9
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 10
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 12
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "random < zero",
+    "text": "random < zero",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 13
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 203,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 203,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 27
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Negative",
+    "text": "Disabled, Negative",
+    "offset": 211,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 229,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 231,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 232,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 232,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 233,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 237,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 240,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 241,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 241,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 242,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 243,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 246,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 247,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 247,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/09.if-else-nested-[if-else-if-else].svelte.json
+++ b/test/baselines/template-lexer/03.if/09.if-else-nested-[if-else-if-else].svelte.json
@@ -1,0 +1,776 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "text": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 84,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 116,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Positive",
+    "text": "Disabled, Positive",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 176,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 9
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 10
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 12
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "random < zero",
+    "text": "random < zero",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 13
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 203,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 203,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 27
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Negative",
+    "text": "Disabled, Negative",
+    "offset": 211,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 229,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 231,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 232,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 232,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 233,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 237,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 242,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 243,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 243,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 248,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Zero",
+    "text": "Disabled, Zero",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 265,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 267,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 268,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 268,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 269,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 26
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 272,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 273,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 276,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 277,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 277,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 278,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 279,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 282,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 283,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 283,
+    "lineBreaks": 1,
+    "line": 17,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/10.if-nested-[if]-else-nested-[if].svelte.json
+++ b/test/baselines/template-lexer/03.if/10.if-nested-[if]-else-nested-[if].svelte.json
@@ -1,0 +1,560 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "text": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 84,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 121,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Enabled, Positive",
+    "text": "Enabled, Positive",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 150,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 158,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 166,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 188,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Positive",
+    "text": "Disabled, Positive",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 214,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 217,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 217,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 218,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 222,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 225,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 226,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 226,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 227,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 228,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 231,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 232,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 232,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/11.if-nested-[if-else]-else-nested-[if-else].svelte.json
+++ b/test/baselines/template-lexer/03.if/11.if-nested-[if-else]-else-nested-[if-else].svelte.json
@@ -1,0 +1,830 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "text": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 84,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 121,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Enabled, Positive",
+    "text": "Enabled, Positive",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 150,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 160,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Enabled, Not Positive",
+    "text": "Enabled, Not Positive",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 193,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 201,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 201,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 203,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 209,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 230,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 231,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 231,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 237,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 238,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 238,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Positive",
+    "text": "Disabled, Positive",
+    "offset": 239,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 257,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 259,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 260,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 260,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 261,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 264,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 265,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 270,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 271,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 271,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 276,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 277,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 278,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 278,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Not Positive",
+    "text": "Disabled, Not Positive",
+    "offset": 279,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 301,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 303,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 304,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 33
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 304,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 305,
+    "lineBreaks": 1,
+    "line": 17,
+    "col": 34
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 308,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 309,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 312,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 313,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 313,
+    "lineBreaks": 1,
+    "line": 18,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 314,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 315,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 318,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 319,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 319,
+    "lineBreaks": 1,
+    "line": 19,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/12.if-nested-[if-else-if]-else-nested-[if-else-if-else].svelte.json
+++ b/test/baselines/template-lexer/03.if/12.if-nested-[if-else-if]-else-nested-[if-else-if-else].svelte.json
@@ -1,0 +1,1055 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "text": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 84,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 121,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Enabled, Positive",
+    "text": "Enabled, Positive",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 150,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 9
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 10
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 12
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "random < zero",
+    "text": "random < zero",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 13
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 177,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Enabled, Negative",
+    "text": "Enabled, Negative",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 204,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 206,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 214,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 214,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 215,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 222,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 222,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 225,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 226,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 229,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 243,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 244,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 244,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Positive",
+    "text": "Disabled, Positive",
+    "offset": 252,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 270,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 272,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 273,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 273,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 274,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 277,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 278,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 283,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 9
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 284,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 10
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 286,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 12
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "random < zero",
+    "text": "random < zero",
+    "offset": 287,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 13
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 300,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 26
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 300,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 301,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 301,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 27
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 306,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 307,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 308,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 308,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Negative",
+    "text": "Disabled, Negative",
+    "offset": 309,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 327,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 329,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 330,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 330,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 331,
+    "lineBreaks": 1,
+    "line": 17,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 334,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 335,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 340,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 341,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 341,
+    "lineBreaks": 1,
+    "line": 18,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 346,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 347,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 348,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 348,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Zero",
+    "text": "Disabled, Zero",
+    "offset": 349,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 363,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 365,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 366,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 366,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 367,
+    "lineBreaks": 1,
+    "line": 19,
+    "col": 26
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 370,
+    "lineBreaks": 0,
+    "line": 20,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 371,
+    "lineBreaks": 0,
+    "line": 20,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 374,
+    "lineBreaks": 0,
+    "line": 20,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 375,
+    "lineBreaks": 0,
+    "line": 20,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 375,
+    "lineBreaks": 1,
+    "line": 20,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 376,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 377,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 380,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 381,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 381,
+    "lineBreaks": 1,
+    "line": 21,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/03.if/13.if-nested-[if-else-if-else]-else-nested-[if-else-if-else].svelte.json
+++ b/test/baselines/template-lexer/03.if/13.if-nested-[if-else-if-else]-else-nested-[if-else-if-else].svelte.json
@@ -1,0 +1,1190 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "text": "\n  const enabled = true,\n    random = Math.random(),\n    zero = 0;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 84,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 121,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Enabled, Positive",
+    "text": "Enabled, Positive",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 150,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 9
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 10
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 12
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "random < zero",
+    "text": "random < zero",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 13
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 177,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Enabled, Negative",
+    "text": "Enabled, Negative",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 204,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 206,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 215,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 216,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 222,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 223,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 223,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Enabled, Zero",
+    "text": "Enabled, Zero",
+    "offset": 224,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 237,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 239,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 240,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 240,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 241,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 25
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 244,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 245,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 248,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 249,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 256,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 257,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 257,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 260,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 3
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 261,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 4
+  },
+  {
+    "type": "_if_expression",
+    "value": " random > zero",
+    "text": " random > zero",
+    "offset": 264,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 278,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 279,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 279,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 284,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 285,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 286,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 286,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Positive",
+    "text": "Disabled, Positive",
+    "offset": 287,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 305,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 307,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 308,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 308,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 309,
+    "lineBreaks": 1,
+    "line": 17,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 312,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 313,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 318,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 9
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 319,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 10
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 321,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 12
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "random < zero",
+    "text": "random < zero",
+    "offset": 322,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 13
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 335,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 26
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 335,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 336,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 336,
+    "lineBreaks": 1,
+    "line": 18,
+    "col": 27
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 341,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 342,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 343,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 343,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Negative",
+    "text": "Disabled, Negative",
+    "offset": 344,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 362,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 364,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 365,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 365,
+    "lineBreaks": 0,
+    "line": 19,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 366,
+    "lineBreaks": 1,
+    "line": 19,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 369,
+    "lineBreaks": 0,
+    "line": 20,
+    "col": 3
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 370,
+    "lineBreaks": 0,
+    "line": 20,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 375,
+    "lineBreaks": 0,
+    "line": 20,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 376,
+    "lineBreaks": 0,
+    "line": 20,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n    ",
+    "text": "\n    ",
+    "offset": 376,
+    "lineBreaks": 1,
+    "line": 20,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 381,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 382,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 6
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 383,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 7
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 383,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 7
+  },
+  {
+    "type": "_body",
+    "value": "Disabled, Zero",
+    "text": "Disabled, Zero",
+    "offset": 384,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 8
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 398,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 400,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 401,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 401,
+    "lineBreaks": 0,
+    "line": 21,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 402,
+    "lineBreaks": 1,
+    "line": 21,
+    "col": 26
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 405,
+    "lineBreaks": 0,
+    "line": 22,
+    "col": 3
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 406,
+    "lineBreaks": 0,
+    "line": 22,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 409,
+    "lineBreaks": 0,
+    "line": 22,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 410,
+    "lineBreaks": 0,
+    "line": 22,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 410,
+    "lineBreaks": 1,
+    "line": 22,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 411,
+    "lineBreaks": 0,
+    "line": 23,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 412,
+    "lineBreaks": 0,
+    "line": 23,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 415,
+    "lineBreaks": 0,
+    "line": 23,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 416,
+    "lineBreaks": 0,
+    "line": 23,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 416,
+    "lineBreaks": 1,
+    "line": 23,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/01.context.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/01.context.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 75,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 92,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 100,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/02.context-index.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/02.context-index.svelte.json
@@ -1,0 +1,416 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 109,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/03.context-key-expression.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/03.context-key-expression.svelte.json
@@ -1,0 +1,353 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 83,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 100,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 108,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/04.context-key-identifier.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/04.context-key-identifier.svelte.json
@@ -1,0 +1,344 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 107,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/05.context-index-key-expression.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/05.context-index-key-expression.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 90,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 125,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/06.context-index-key-identifier.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/06.context-index-key-identifier.svelte.json
@@ -1,0 +1,443 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 89,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 116,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/07.context-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/07.context-else.svelte.json
@@ -1,0 +1,461 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 75,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 92,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 100,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 118,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 126,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/08.context-index-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/08.context-index-else.svelte.json
@@ -1,0 +1,551 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 109,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 135,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 143,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/09.context-key-expression-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/09.context-key-expression-else.svelte.json
@@ -1,0 +1,488 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 83,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 100,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 108,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 126,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 134,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/10.context-key-identifier-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/10.context-key-identifier-else.svelte.json
@@ -1,0 +1,479 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 107,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 125,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 133,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/11.context-index-key-expression-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/11.context-index-key-expression-else.svelte.json
@@ -1,0 +1,587 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 90,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 125,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 143,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 151,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/01.identifier-context/12.context-index-key-identifier-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/01.identifier-context/12.context-index-key-identifier-else.svelte.json
@@ -1,0 +1,578 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 89,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 116,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 142,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 150,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/01.context.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/01.context.svelte.json
@@ -1,0 +1,398 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 115,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 138,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/02.context-index.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/02.context-index.svelte.json
@@ -1,0 +1,488 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 122,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 155,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 163,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/03.context-key-expression.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/03.context-key-expression.svelte.json
@@ -1,0 +1,434 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 35
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 123,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 37
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 154,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/04.context-key-identifier.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/04.context-key-identifier.svelte.json
@@ -1,0 +1,425 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 122,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 145,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 153,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/05.context-index-key-expression.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/05.context-index-key-expression.svelte.json
@@ -1,0 +1,524 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 35
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 37
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 43
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 130,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 44
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 163,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 171,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/06.context-index-key-identifier.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/06.context-index-key-identifier.svelte.json
@@ -1,0 +1,515 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 35
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 37
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 43
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 129,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 43
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 162,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 170,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/07.context-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/07.context-else.svelte.json
@@ -1,0 +1,533 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 115,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 138,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 164,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 172,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/08.context-index-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/08.context-index-else.svelte.json
@@ -1,0 +1,623 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 122,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 155,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 163,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 181,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 189,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/09.context-key-expression-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/09.context-key-expression-else.svelte.json
@@ -1,0 +1,569 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 35
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 123,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 37
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 154,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 172,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 180,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/10.context-key-identifier-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/10.context-key-identifier-else.svelte.json
@@ -1,0 +1,560 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 122,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 145,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 153,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 171,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 179,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/11.context-index-key-expression-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/11.context-index-key-expression-else.svelte.json
@@ -1,0 +1,659 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 35
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 37
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 43
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 130,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 44
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 163,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 171,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 189,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 197,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/02.object-context/12.context-index-key-identifier-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/02.object-context/12.context-index-key-identifier-else.svelte.json
@@ -1,0 +1,650 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id, title",
+    "text": "id, title",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 35
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 37
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 43
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 129,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 43
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 162,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 170,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 188,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 196,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/01.context.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/01.context.svelte.json
@@ -1,0 +1,398 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 149,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 172,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 180,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/02.context-index.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/02.context-index.svelte.json
@@ -1,0 +1,488 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 156,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 189,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 197,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/03.context-key-expression.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/03.context-key-expression.svelte.json
@@ -1,0 +1,434 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 11
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 157,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 11
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 180,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 188,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/04.context-key-identifier.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/04.context-key-identifier.svelte.json
@@ -1,0 +1,425 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 156,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 179,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 187,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/05.context-index-key-expression.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/05.context-index-key-expression.svelte.json
@@ -1,0 +1,524 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 9
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 11
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 164,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 18
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 197,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 198,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 204,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 205,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/06.context-index-key-identifier.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/06.context-index-key-identifier.svelte.json
@@ -1,0 +1,515 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 9
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 11
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 163,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 196,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 198,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 203,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 204,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 204,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/07.context-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/07.context-else.svelte.json
@@ -1,0 +1,533 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 149,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 172,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 180,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 198,
+    "lineBreaks": 1,
+    "line": 17,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 206,
+    "lineBreaks": 1,
+    "line": 18,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/08.context-index-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/08.context-index-else.svelte.json
@@ -1,0 +1,623 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 156,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 189,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 197,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 201,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 203,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 211,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 214,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 214,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 215,
+    "lineBreaks": 1,
+    "line": 17,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 217,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 222,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 223,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 223,
+    "lineBreaks": 1,
+    "line": 18,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/09.context-key-expression-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/09.context-key-expression-else.svelte.json
@@ -1,0 +1,569 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 11
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 157,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 11
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 180,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 188,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 204,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 206,
+    "lineBreaks": 1,
+    "line": 17,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 214,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 214,
+    "lineBreaks": 1,
+    "line": 18,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/10.context-key-identifier-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/10.context-key-identifier-else.svelte.json
@@ -1,0 +1,560 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 156,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 179,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 187,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 201,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 203,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 204,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 204,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 205,
+    "lineBreaks": 1,
+    "line": 17,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 213,
+    "lineBreaks": 1,
+    "line": 18,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/11.context-index-key-expression-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/11.context-index-key-expression-else.svelte.json
@@ -1,0 +1,659 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 9
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 11
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 164,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 18
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 197,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 198,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 204,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 205,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 211,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 219,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 222,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 222,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 223,
+    "lineBreaks": 1,
+    "line": 17,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 224,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 225,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 230,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 231,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 231,
+    "lineBreaks": 1,
+    "line": 18,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/04.each/03.array-context/12.context-index-key-identifier-else.svelte.json
+++ b/test/baselines/template-lexer/04.each/03.array-context/12.context-index-key-identifier-else.svelte.json
@@ -1,0 +1,650 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "\n  id,\n  title\n",
+    "text": "\n  id,\n  title\n",
+    "offset": 132,
+    "lineBreaks": 3,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 1
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 3
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 9
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 10
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 11
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 14,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 163,
+    "lineBreaks": 1,
+    "line": 14,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 7
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 15,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 196,
+    "lineBreaks": 1,
+    "line": 15,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 198,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 203,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 204,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 204,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts",
+    "text": "No posts",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 218,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 220,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 17,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 222,
+    "lineBreaks": 1,
+    "line": 17,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 223,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 224,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 229,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 230,
+    "lineBreaks": 0,
+    "line": 18,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 230,
+    "lineBreaks": 1,
+    "line": 18,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/05.await/01.full-catch.svelte.json
+++ b/test/baselines/template-lexer/05.await/01.full-catch.svelte.json
@@ -1,0 +1,650 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting...",
+    "text": "Waiting...",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 147,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 162,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 190,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 198,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 199,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/05.await/02.full-no-catch.svelte.json
+++ b/test/baselines/template-lexer/05.await/02.full-no-catch.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting...",
+    "text": "Waiting...",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 147,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 156,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/05.await/03.compact-catch.svelte.json
+++ b/test/baselines/template-lexer/05.await/03.compact-catch.svelte.json
@@ -1,0 +1,524 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise ",
+    "text": "promise ",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "await_compact_then",
+    "value": "then",
+    "text": "then",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_await_then_compact_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 139,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 167,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 176,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/05.await/04.compact-no-catch.svelte.json
+++ b/test/baselines/template-lexer/05.await/04.compact-no-catch.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise ",
+    "text": "promise ",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "await_compact_then",
+    "value": "then",
+    "text": "then",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_await_then_compact_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 133,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/06.directives/01.actions/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/06.directives/01.actions/01.no-expression.svelte.json
@@ -1,0 +1,209 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove();\n",
+    "text": "\n  const action = (node) => node.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 60,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 88,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 27
+  }
+]

--- a/test/baselines/template-lexer/06.directives/01.actions/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/01.actions/02.unquoted-identifier.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "text": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 92,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "options",
+    "text": "options",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 130,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/06.directives/01.actions/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/01.actions/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "text": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 92,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "options",
+    "text": "options",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 132,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/06.directives/01.actions/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/01.actions/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "text": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 92,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "options",
+    "text": "options",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 132,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/06.directives/01.actions/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/01.actions/05.unquoted-object.svelte.json
@@ -1,0 +1,317 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove();\n",
+    "text": "\n  const action = (node) => node.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 60,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "option",
+    "text": "option",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": true",
+    "text": ": true",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 40
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 42
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 45
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 45
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 107,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 46
+  }
+]

--- a/test/baselines/template-lexer/06.directives/01.actions/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/01.actions/06.double-quoted-object.svelte.json
@@ -1,0 +1,335 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove();\n",
+    "text": "\n  const action = (node) => node.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 60,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "option",
+    "text": "option",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": true",
+    "text": ": true",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 42
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 47
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 47
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 109,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 48
+  }
+]

--- a/test/baselines/template-lexer/06.directives/01.actions/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/01.actions/07.single-quoted-object.svelte.json
@@ -1,0 +1,335 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove();\n",
+    "text": "\n  const action = (node) => node.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 60,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "option",
+    "text": "option",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": true",
+    "text": ": true",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 42
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 47
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 47
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 109,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 48
+  }
+]

--- a/test/baselines/template-lexer/06.directives/02.animation/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/06.directives/02.animation/01.no-expression.svelte.json
@@ -1,0 +1,380 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    titles = [\"A Blog Post\"];\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 136,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 168,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 195,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 203,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 203,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/06.directives/02.animation/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/02.animation/02.unquoted-identifier.svelte.json
@@ -1,0 +1,443 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 181,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 213,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 217,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 220,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 228,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 229,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 234,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 235,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 235,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 246,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 247,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 247,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 247,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 34
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 247,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 34
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 247,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 34
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 248,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 35
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 37
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 253,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 40
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 253,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 40
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 254,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 41
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 255,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 256,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 261,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 262,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 262,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/06.directives/02.animation/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/02.animation/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,461 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 181,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 213,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 217,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 220,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 228,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 229,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 234,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 235,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 247,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 248,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 35
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 248,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 252,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 255,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 255,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 256,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 43
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 257,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 258,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 263,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 264,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 264,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/06.directives/02.animation/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/02.animation/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,461 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 181,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 213,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 217,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 220,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 228,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 229,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 234,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 235,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 247,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 248,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 35
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 248,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 252,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 255,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 255,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 256,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 43
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 257,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 258,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 263,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 264,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 264,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/06.directives/02.animation/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/02.animation/05.unquoted-object.svelte.json
@@ -1,0 +1,488 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    titles = [\"A Blog Post\"];\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 136,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 168,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 32
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 201,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 33
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 38
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 39
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 40
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 40
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 40
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 40
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 40
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 41
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 211,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 43
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 214,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 46
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 214,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 46
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 215,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 47
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 217,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 222,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 223,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 223,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/06.directives/02.animation/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/02.animation/06.double-quoted-object.svelte.json
@@ -1,0 +1,506 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    titles = [\"A Blog Post\"];\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 136,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 168,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 201,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 33
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 34
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 39
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 40
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 41
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 41
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 211,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 43
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 45
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 48
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 48
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 217,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 49
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 218,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 219,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 224,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 225,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 225,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/06.directives/02.animation/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/02.animation/07.single-quoted-object.svelte.json
@@ -1,0 +1,506 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    titles = [\"A Blog Post\"];\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 136,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 168,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 201,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 33
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 202,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 34
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 39
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 40
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 41
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 41
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 211,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 43
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 45
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 48
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 48
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 217,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 49
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 218,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 219,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 224,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 225,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 225,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/01.no-expression.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"some value\";\n",
+    "text": "\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 48,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 70,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/02.unquoted-identifier.svelte.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"some value\";\n",
+    "text": "\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 48,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 78,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"some value\";\n",
+    "text": "\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 48,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 80,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 31
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"some value\";\n",
+    "text": "\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 48,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 80,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 31
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/05.number.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/05.number.svelte.json
@@ -1,0 +1,335 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const number = 1;\n",
+    "text": "\n  const number = 1;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 38,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "type",
+    "text": "type",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "number",
+    "text": "number",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "number",
+    "text": "number",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 40
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 42
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 83,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 44
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/06.checkbox.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/06.checkbox.svelte.json
@@ -1,0 +1,434 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const checked = true,\n    value = \"some value\";\n",
+    "text": "\n  const checked = true,\n    value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 68,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "type",
+    "text": "type",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "checkbox",
+    "text": "checkbox",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "checked",
+    "text": "checked",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 48
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 49
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 50
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 50
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 55
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 56
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 56
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 57
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 57
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 57
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 58
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 58
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 129,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 60
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/07.multiple-checkboxes.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/07.multiple-checkboxes.svelte.json
@@ -1,0 +1,911 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const array = [],\n    checked = true,\n    checked2 = false;\n",
+    "text": "\n  const array = [],\n    checked = true,\n    checked2 = false;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 80,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "type",
+    "text": "type",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "checkbox",
+    "text": "checkbox",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "group",
+    "text": "group",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "array",
+    "text": "array",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 42
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 44
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 44
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 44
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 45
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 45
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 45
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 49
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "checked",
+    "text": "checked",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 50
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 57
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 57
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 57
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 57
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 58
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 58
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 141,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 60
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "type",
+    "text": "type",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "checkbox",
+    "text": "checkbox",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "group",
+    "text": "group",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 34
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 34
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 35
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 36
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 37
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "array",
+    "text": "array",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 37
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 42
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 43
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 43
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 44
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 44
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 44
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 45
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 45
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 45
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 49
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "checked",
+    "text": "checked",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 50
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 198,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 57
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 198,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 57
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 198,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 57
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 58
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 59
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 201,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 60
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "checked2",
+    "text": "checked2",
+    "offset": 201,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 60
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 68
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 69
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 69
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 211,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 70
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 211,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 70
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 211,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 70
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 71
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 71
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 214,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 73
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/08.radio.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/08.radio.svelte.json
@@ -1,0 +1,866 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const array = [],\n    value = \"some value\",\n    value2 = \"another value\";\n",
+    "text": "\n  const array = [],\n    value = \"some value\",\n    value2 = \"another value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 94,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "type",
+    "text": "type",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "radio",
+    "text": "radio",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "group",
+    "text": "group",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 33
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "array",
+    "text": "array",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 33
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "value",
+    "text": "value",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 45
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 45
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 46
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 47
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 47
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 52
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 53
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 53
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 53
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 53
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 54
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 54
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 151,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 56
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "type",
+    "text": "type",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "radio",
+    "text": "radio",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "group",
+    "text": "group",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 32
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 33
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "array",
+    "text": "array",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 33
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 38
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 39
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 39
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 39
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 39
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 40
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 40
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "value",
+    "text": "value",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 40
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 45
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 196,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 45
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 46
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 198,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 47
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value2",
+    "text": "value2",
+    "offset": 198,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 47
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 204,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 53
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 54
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 54
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 54
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 205,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 54
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 55
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 55
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 208,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 57
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/09.textarea.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/09.textarea.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"some value\";\n",
+    "text": "\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 48,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "textarea",
+    "text": "textarea",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "textarea",
+    "text": "textarea",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 33
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/10.select.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/10.select.svelte.json
@@ -1,0 +1,623 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"some value\";\n",
+    "text": "\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 48,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "select",
+    "text": "select",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 69,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "option",
+    "text": "option",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "value",
+    "text": "value",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "option",
+    "text": "option",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 98,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "option",
+    "text": "option",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "value",
+    "text": "value",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "html_tag_name",
+    "value": "option",
+    "text": "option",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 139,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 41
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "select",
+    "text": "select",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 149,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/11.audio.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/11.audio.svelte.json
@@ -1,0 +1,416 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const paused = false,\n    time = 33;\n",
+    "text": "\n  const paused = false,\n    time = 33;\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 57,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "audio",
+    "text": "audio",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "src",
+    "text": "src",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "audio.mp3",
+    "text": "audio.mp3",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "currentTime",
+    "text": "currentTime",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "time",
+    "text": "time",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 46
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 48
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 48
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 48
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 52
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "paused",
+    "text": "paused",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 53
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 59
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 59
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 59
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 59
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 60
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 60
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 120,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 62
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/12.video.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/12.video.svelte.json
@@ -1,0 +1,416 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const paused = false,\n    time = 33;\n",
+    "text": "\n  const paused = false,\n    time = 33;\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 57,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "video",
+    "text": "video",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "src",
+    "text": "src",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "audio.mp3",
+    "text": "audio.mp3",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "currentTime",
+    "text": "currentTime",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "time",
+    "text": "time",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 46
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 48
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 48
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 48
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 52
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "paused",
+    "text": "paused",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 53
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 59
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 59
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 59
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 59
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 60
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 60
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 120,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 62
+  }
+]

--- a/test/baselines/template-lexer/06.directives/03.bindings/13.component.svelte.json
+++ b/test/baselines/template-lexer/06.directives/03.bindings/13.component.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n\n  const prop = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "prop",
+    "text": "prop",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "prop",
+    "text": "prop",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 29
+  }
+]

--- a/test/baselines/template-lexer/06.directives/04.class/01.attribute-expression.svelte.json
+++ b/test/baselines/template-lexer/06.directives/04.class/01.attribute-expression.svelte.json
@@ -1,0 +1,245 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const active = \"active\";\n",
+    "text": "\n  const active = \"active\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 45,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "active",
+    "text": "active",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 77,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 31
+  }
+]

--- a/test/baselines/template-lexer/06.directives/04.class/02.directive-shorthand.svelte.json
+++ b/test/baselines/template-lexer/06.directives/04.class/02.directive-shorthand.svelte.json
@@ -1,0 +1,209 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const active = true;\n",
+    "text": "\n  const active = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 41,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "active",
+    "text": "active",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 71,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  }
+]

--- a/test/baselines/template-lexer/06.directives/04.class/03.directive-unquoted.svelte.json
+++ b/test/baselines/template-lexer/06.directives/04.class/03.directive-unquoted.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const active = true;\n",
+    "text": "\n  const active = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 41,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "active",
+    "text": "active",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "active",
+    "text": "active",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 80,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 38
+  }
+]

--- a/test/baselines/template-lexer/06.directives/04.class/04.directive-double-quoted.svelte.json
+++ b/test/baselines/template-lexer/06.directives/04.class/04.directive-double-quoted.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const active = true;\n",
+    "text": "\n  const active = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 41,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "active",
+    "text": "active",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "active",
+    "text": "active",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 40
+  }
+]

--- a/test/baselines/template-lexer/06.directives/04.class/05.directive-single-quoted.svelte.json
+++ b/test/baselines/template-lexer/06.directives/04.class/05.directive-single-quoted.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const active = true;\n",
+    "text": "\n  const active = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 41,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "active",
+    "text": "active",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "active",
+    "text": "active",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 40
+  }
+]

--- a/test/baselines/template-lexer/06.directives/05.event-handlers/01.bubble.svelte.json
+++ b/test/baselines/template-lexer/06.directives/05.event-handlers/01.bubble.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 30
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 30,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 31
+  }
+]

--- a/test/baselines/template-lexer/06.directives/05.event-handlers/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/05.event-handlers/02.unquoted-identifier.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const handler = (event) => event.target.remove();\n",
+    "text": "\n  const handler = (event) => event.target.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 70,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "handler",
+    "text": "handler",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 106,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 35
+  }
+]

--- a/test/baselines/template-lexer/06.directives/05.event-handlers/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/05.event-handlers/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const handler = (event) => event.target.remove();\n",
+    "text": "\n  const handler = (event) => event.target.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 70,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "handler",
+    "text": "handler",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 108,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/06.directives/05.event-handlers/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/05.event-handlers/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const handler = (event) => event.target.remove();\n",
+    "text": "\n  const handler = (event) => event.target.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 70,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "handler",
+    "text": "handler",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 108,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/06.directives/05.event-handlers/05.unquoted-inline.svelte.json
+++ b/test/baselines/template-lexer/06.directives/05.event-handlers/05.unquoted-inline.svelte.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "(event) => event.target.remove()",
+    "text": "(event) => event.target.remove()",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 48
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 49
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 49
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 49
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 49
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 49
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 50
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 54
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 56
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 59
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 59
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 59,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 60
+  }
+]

--- a/test/baselines/template-lexer/06.directives/05.event-handlers/06.double-quoted-inline.svelte.json
+++ b/test/baselines/template-lexer/06.directives/05.event-handlers/06.double-quoted-inline.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "(event) => event.target.remove()",
+    "text": "(event) => event.target.remove()",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 49
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 50
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 50
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 51
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 51
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 51
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 51
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 52
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 56
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 58
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 61
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 61
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 61,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 62
+  }
+]

--- a/test/baselines/template-lexer/06.directives/05.event-handlers/07.single-quoted-inline.svelte.json
+++ b/test/baselines/template-lexer/06.directives/05.event-handlers/07.single-quoted-inline.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "(event) => event.target.remove()",
+    "text": "(event) => event.target.remove()",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 49
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 50
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 50
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 51
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 51
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 51
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 51
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 52
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 56
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 58
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 61
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 61
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 61,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 62
+  }
+]

--- a/test/baselines/template-lexer/06.directives/06.let/01.shorthand.svelte.json
+++ b/test/baselines/template-lexer/06.directives/06.let/01.shorthand.svelte.json
@@ -1,0 +1,245 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 75,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 27
+  }
+]

--- a/test/baselines/template-lexer/06.directives/06.let/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/06.let/02.unquoted-identifier.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 34
+  }
+]

--- a/test/baselines/template-lexer/06.directives/06.let/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/06.let/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 84,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 36
+  }
+]

--- a/test/baselines/template-lexer/06.directives/06.let/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/06.let/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 84,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 36
+  }
+]

--- a/test/baselines/template-lexer/06.directives/06.let/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/06.let/05.unquoted-object.svelte.json
@@ -1,0 +1,389 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 42
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "name",
+    "text": "name",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 42
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 46
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 47
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 47
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 49
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 52
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 52
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 101,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 53
+  }
+]

--- a/test/baselines/template-lexer/06.directives/06.let/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/06.let/06.double-quoted-object.svelte.json
@@ -1,0 +1,407 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 40
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 43
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "name",
+    "text": "name",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 48
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 49
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 49
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 51
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 54
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 54
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 103,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 55
+  }
+]

--- a/test/baselines/template-lexer/06.directives/06.let/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/06.let/07.single-quoted-object.svelte.json
@@ -1,0 +1,407 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 40
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 43
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "name",
+    "text": "name",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 48
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 49
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 49
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 51
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 54
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 54
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 103,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 55
+  }
+]

--- a/test/baselines/template-lexer/06.directives/06.let/08.unquoted-array.svelte.json
+++ b/test/baselines/template-lexer/06.directives/06.let/08.unquoted-array.svelte.json
@@ -1,0 +1,371 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 64,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "name",
+    "text": "name",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 107,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/06.directives/06.let/09.double-quoted-array.svelte.json
+++ b/test/baselines/template-lexer/06.directives/06.let/09.double-quoted-array.svelte.json
@@ -1,0 +1,389 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 65,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "name",
+    "text": "name",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 109,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 27
+  }
+]

--- a/test/baselines/template-lexer/06.directives/06.let/10.single-quoted-array.svelte.json
+++ b/test/baselines/template-lexer/06.directives/06.let/10.single-quoted-array.svelte.json
@@ -1,0 +1,389 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 65,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "index",
+    "text": "index",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "name",
+    "text": "name",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 109,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 27
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/01.no-expression.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 135,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/02.unquoted-identifier.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 41
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 194,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 42
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 196,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 44
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 196,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 44
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/05.unquoted-object.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 39
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 44
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 47
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 155,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 48
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/06.double-quoted-object.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 44
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 46
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 49
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 49
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 157,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 50
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/01.bidirectional/07.single-quoted-object.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 44
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 46
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 49
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 49
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 157,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 50
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/02.in/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/02.in/01.no-expression.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 127,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/02.in/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/02.in/02.unquoted-identifier.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 33
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 186,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 34
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/02.in/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/02.in/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 188,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 36
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/02.in/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/02.in/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 188,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 36
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/02.in/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/02.in/05.unquoted-object.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 31
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 39
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 147,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 40
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/02.in/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/02.in/06.double-quoted-object.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 149,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 42
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/02.in/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/02.in/07.single-quoted-object.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 149,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 42
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/03.out/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/03.out/01.no-expression.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 128,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/03.out/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/03.out/02.unquoted-identifier.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 187,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 35
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/03.out/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/03.out/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 189,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/03.out/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/03.out/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 189,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/03.out/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/03.out/05.unquoted-object.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 148,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 41
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/03.out/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/03.out/06.double-quoted-object.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 150,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 43
+  }
+]

--- a/test/baselines/template-lexer/06.directives/07.transitions/03.out/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/06.directives/07.transitions/03.out/07.single-quoted-object.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 150,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 43
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/01.content-mustache.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/01.content-mustache.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "$count",
+    "text": "$count",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 72,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 20
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/02.unquoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/02.unquoted-attribute.svelte.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "$count",
+    "text": "$count",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/03.double-quoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/03.double-quoted-attribute.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "$count",
+    "text": "$count",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 78,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/04.single-quoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/04.single-quoted-attribute.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "$count",
+    "text": "$count",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 78,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/05.if.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/05.if.svelte.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n\n  const min = 0;\n",
+    "text": "\n  import {count} from \"./store\";\n\n  const min = 0;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 69,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " $count > min",
+    "text": " $count > min",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 89,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Positive",
+    "text": "Positive",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 107,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 113,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/06.else.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/01.imported/06.else.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {posts} from \"./store\";\n",
+    "text": "\n  import {posts} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "$posts ",
+    "text": "$posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 93,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 101,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/01.content-mustache.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/01.content-mustache.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "$store",
+    "text": "$store",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 131,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 20
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/02.unquoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/02.unquoted-attribute.svelte.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "$store",
+    "text": "$store",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 135,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/03.double-quoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/03.double-quoted-attribute.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "$store",
+    "text": "$store",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 137,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/04.single-quoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/04.single-quoted-attribute.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "$store",
+    "text": "$store",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 137,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/05.if.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/05.if.svelte.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n\n  const min = 0;\n",
+    "text": "\n  import {count} from \"./store\";\n\n  const min = 0;\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 69,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " $count > min",
+    "text": " $count > min",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 89,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Positive",
+    "text": "Positive",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 107,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 113,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/06.else.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/01.store-auto-subscription/02.self-declared/06.else.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const posts = readable([]);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const posts = readable([]);\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "$posts ",
+    "text": "$posts ",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 115,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 132,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 140,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/02.exports/01.instance-let.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/02.exports/01.instance-let.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  export let value = \"some value\";\n",
+    "text": "\n  export let value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 53,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 75,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/02.exports/02.instance-const.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/02.exports/02.instance-const.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  export const value = \"some value\";\n",
+    "text": "\n  export const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 55,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 77,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/02.exports/03.module-let.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/02.exports/03.module-let.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script context=\"module\">",
+    "text": "<script context=\"module\">",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  export let value = \"some value\";\n",
+    "text": "\n  export let value = \"some value\";\n",
+    "offset": 25,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 70,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 92,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/02.exports/04.module-const.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/02.exports/04.module-const.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script context=\"module\">",
+    "text": "<script context=\"module\">",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  export const value = \"some value\";\n",
+    "text": "\n  export const value = \"some value\";\n",
+    "offset": 25,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 72,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/03.undeclared-props/01.component-tag-pair.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/03.undeclared-props/01.component-tag-pair.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "...$$props",
+    "text": "...$$props",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 73,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/03.undeclared-props/03.component-self-closing.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/03.undeclared-props/03.component-self-closing.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "...$$props",
+    "text": "...$$props",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 69,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/07.implicit/04.reactive-declarations/01.simple-assignment.svelte.json
+++ b/test/baselines/template-lexer/07.implicit/04.reactive-declarations/01.simple-assignment.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  export let changeable = 2;\n\n  const double = 2;\n\n  $: reactive = changeable * double;\n",
+    "text": "\n  export let changeable = 2;\n\n  const double = 2;\n\n  $: reactive = changeable * double;\n",
+    "offset": 8,
+    "lineBreaks": 6,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Double: ",
+    "text": "Double: ",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "reactive",
+    "text": "reactive",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 137,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/01.simple-mustache/01.text.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/01.simple-mustache/01.text.svelte.json
@@ -1,0 +1,128 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 18,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 19
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/01.simple-mustache/02.unquoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/01.simple-mustache/02.unquoted-attribute.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 19,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 20
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/01.simple-mustache/03.double-quote-attribute.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/01.simple-mustache/03.double-quote-attribute.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 21,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/01.simple-mustache/04.single-quote-attribute.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/01.simple-mustache/04.single-quote-attribute.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 21,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/01.simple-mustache/05.shorthand-attribute.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/01.simple-mustache/05.shorthand-attribute.svelte.json
@@ -1,0 +1,155 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id",
+    "text": "id",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 16,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 17
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/01.simple-mustache/06.store-auto-subscription.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/01.simple-mustache/06.store-auto-subscription.svelte.json
@@ -1,0 +1,128 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "$store",
+    "text": "$store",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 19,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 20
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/02.component/07.block.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/02.component/07.block.svelte.json
@@ -1,0 +1,83 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 11,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 12
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/02.component/08.self-closing.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/02.component/08.self-closing.svelte.json
@@ -1,0 +1,56 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 7,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/03.if/01.if.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/03.if/01.if.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 13,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 30,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 36,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/03.if/02.if-else-if.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/03.if/02.if-else-if.svelte.json
@@ -1,0 +1,371 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 13,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 30,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "number > zero",
+    "text": "number > zero",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 24
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 55,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 25
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Positive",
+    "text": "Positive",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 73,
+    "lineBreaks": 1,
+    "line": 4,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 79,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/04.each/01.main-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/04.each/01.main-expression.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "post",
+    "text": "post",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 21,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "post",
+    "text": "post",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 11
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 12
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 12
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 14
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 37,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 45,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/04.each/02.context-in-else.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/04.each/02.context-in-else.svelte.json
@@ -1,0 +1,506 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "post",
+    "text": "post",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "post",
+    "text": "post",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 90,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 98,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No posts: ",
+    "text": "No posts: ",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "post",
+    "text": "post",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 132,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/04.each/03.key-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/04.each/03.key-expression.svelte.json
@@ -1,0 +1,362 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 39,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "post",
+    "text": "post",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 11
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 12
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 12
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 14
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 55,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 63,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/04.each/04.key-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/04.each/04.key-identifier.svelte.json
@@ -1,0 +1,353 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 38,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "post",
+    "text": "post",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 11
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 12
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 12
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 14
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 54,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 62,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/05.await/01.main-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/05.await/01.main-expression.svelte.json
@@ -1,0 +1,614 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 16,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting",
+    "text": "Waiting",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 33,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 48,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 78,
+    "lineBreaks": 1,
+    "line": 4,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 93,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 121,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 130,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/05.await/02.result-in-pending.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/05.await/02.result-in-pending.svelte.json
@@ -1,0 +1,695 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "Promise.resolve(",
+    "text": "Promise.resolve(",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "some value",
+    "text": "some value",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": ")",
+    "text": ")",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 38,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting ",
+    "text": "Waiting ",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 22
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 64,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 26
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 79,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 109,
+    "lineBreaks": 1,
+    "line": 4,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 152,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 161,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/05.await/03.error-in-pending.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/05.await/03.error-in-pending.svelte.json
@@ -1,0 +1,695 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "Promise.resolve(",
+    "text": "Promise.resolve(",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "some value",
+    "text": "some value",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": ")",
+    "text": ")",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 38,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting ",
+    "text": "Waiting ",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 63,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 25
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 78,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 108,
+    "lineBreaks": 1,
+    "line": 4,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 123,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 151,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 160,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/05.await/04.result-in-catch.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/05.await/04.result-in-catch.svelte.json
@@ -1,0 +1,704 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "Promise.resolve(",
+    "text": "Promise.resolve(",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "some value",
+    "text": "some value",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": ")",
+    "text": ")",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 38,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting",
+    "text": "Waiting",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 55,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 70,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 100,
+    "lineBreaks": 1,
+    "line": 4,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 115,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": " ",
+    "text": " ",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 152,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 161,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/05.await/05.error-in-then.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/05.await/05.error-in-then.svelte.json
@@ -1,0 +1,704 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "Promise.resolve(",
+    "text": "Promise.resolve(",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "some value",
+    "text": "some value",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": ")",
+    "text": ")",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 38,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting",
+    "text": "Waiting",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 55,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 70,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": " ",
+    "text": " ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 26
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 27
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 28
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 33
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 34
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 34
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 36
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 37
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 108,
+    "lineBreaks": 1,
+    "line": 4,
+    "col": 38
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 123,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 151,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 160,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/01.no-expression.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 26,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 27
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/02.unquoted-identifier.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const options = {\"option\": true};\n",
+    "text": "\n  const options = {\"option\": true};\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 54,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "options",
+    "text": "options",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 92,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const options = {\"option\": true};\n",
+    "text": "\n  const options = {\"option\": true};\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 54,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "options",
+    "text": "options",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const options = {\"option\": true};\n",
+    "text": "\n  const options = {\"option\": true};\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 54,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "options",
+    "text": "options",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/05.unquoted-object.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 0,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 2,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 18
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 18
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 19
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "option",
+    "text": "option",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 26
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": true",
+    "text": ": true",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 27
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 33
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 35
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 35
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 40
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 42
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 45
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 45
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 46,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 46
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/06.double-quoted-object.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 0,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 2,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 19
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 19
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "option",
+    "text": "option",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 21
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 27
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": true",
+    "text": ": true",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 28
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 34
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 36
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 37
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 37
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 38
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 42
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 44
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 47
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 47
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 48,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 48
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/06.actions/01.directive-identifier/07.single-quoted-object.svelte.json
@@ -1,0 +1,299 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "option",
+    "text": "option",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": true",
+    "text": ": true",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 44
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 47
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 47
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 47,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 48
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/06.actions/02.expression/01.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/06.actions/02.expression/01.unquoted-identifier.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove();\n",
+    "text": "\n  const action = (node) => node.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 60,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "options",
+    "text": "options",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 98,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/06.actions/02.expression/02.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/06.actions/02.expression/02.double-quoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove();\n",
+    "text": "\n  const action = (node) => node.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 60,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "options",
+    "text": "options",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 100,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/06.actions/02.expression/03.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/06.actions/02.expression/03.single-quoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove();\n",
+    "text": "\n  const action = (node) => node.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 60,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "options",
+    "text": "options",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 100,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/01.no-expression.svelte.json
@@ -1,0 +1,398 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_each_key",
+    "value": "post.id",
+    "text": "post.id",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 41,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 21
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 23
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 68,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/02.unquoted-identifier.svelte.json
@@ -1,0 +1,497 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_each_key",
+    "value": "post.id",
+    "text": "post.id",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 133,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 33
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 174,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 41
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 182,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,515 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_each_key",
+    "value": "post.id",
+    "text": "post.id",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 133,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 176,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 184,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,515 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_each_key",
+    "value": "post.id",
+    "text": "post.id",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 133,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 176,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 184,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/05.unquoted-object.svelte.json
@@ -1,0 +1,506 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_each_key",
+    "value": "post.id",
+    "text": "post.id",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 41,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 21
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 22
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 22
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 23
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 24
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 32
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 33
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 38
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 39
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 40
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 40
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 40
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 40
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 40
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 41
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 43
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 46
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 46
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 88,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 47
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 96,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/06.double-quoted-object.svelte.json
@@ -1,0 +1,524 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_each_key",
+    "value": "post.id",
+    "text": "post.id",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 41,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 23
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 23
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 24
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 25
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 33
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 34
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 39
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 40
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 41
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 41
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 42
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 42
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 42
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 42
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 43
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 45
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 48
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 48
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 90,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 49
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 98,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/07.animations/01.directive-identifier/07.single-quoted-object.svelte.json
@@ -1,0 +1,524 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_each_key",
+    "value": "post.id",
+    "text": "post.id",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 41,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 23
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 23
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 24
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 25
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 33
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 34
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 39
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 40
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 41
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 41
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 42
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 42
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 42
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 42
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 43
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 45
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 48
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 48
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 90,
+    "lineBreaks": 1,
+    "line": 2,
+    "col": 49
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 98,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/07.animations/02.expression/01.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/07.animations/02.expression/01.unquoted-identifier.svelte.json
@@ -1,0 +1,497 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_each_key",
+    "value": "post.id",
+    "text": "post.id",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 149,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 33
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 190,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 41
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 198,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 198,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/07.animations/02.expression/02.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/07.animations/02.expression/02.double-quoted-identifier.svelte.json
@@ -1,0 +1,515 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_each_key",
+    "value": "post.id",
+    "text": "post.id",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 149,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 192,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 200,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/07.animations/02.expression/03.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/07.animations/02.expression/03.single-quoted-identifier.svelte.json
@@ -1,0 +1,515 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "A Blog Post",
+    "text": "A Blog Post",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context",
+    "value": "post ",
+    "text": "post ",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_each_key",
+    "value": "post.id",
+    "text": "post.id",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 149,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 42
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 192,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 200,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/08.bindings/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/08.bindings/01.no-expression.svelte.json
@@ -1,0 +1,137 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 20,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/08.bindings/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/08.bindings/02.unquoted-identifier.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 28,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 29
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/08.bindings/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/08.bindings/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 30,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 31
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/08.bindings/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/08.bindings/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "bind",
+    "text": "bind",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "value",
+    "text": "value",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 30,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 31
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/09.class/01.attribute-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/09.class/01.attribute-expression.svelte.json
@@ -1,0 +1,209 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "active",
+    "text": "active",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 30
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 30,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 31
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/09.class/02.directive-shorthand.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/09.class/02.directive-shorthand.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "active",
+    "text": "active",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 28,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 29
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/09.class/03.directive-double-quoted.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/09.class/03.directive-double-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "active",
+    "text": "active",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "active",
+    "text": "active",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 39,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 40
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/09.class/04.directive-single-quoted.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/09.class/04.directive-single-quoted.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 10,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "active",
+    "text": "active",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "active",
+    "text": "active",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 39,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 40
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/10.event-handlers/01.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/10.event-handlers/01.unquoted-identifier.svelte.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "handler",
+    "text": "handler",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 30,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 34,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 35
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/10.event-handlers/02.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/10.event-handlers/02.double-quoted-identifier.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "handler",
+    "text": "handler",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 30,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 36,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/10.event-handlers/03.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/10.event-handlers/03.single-quoted-identifier.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "handler",
+    "text": "handler",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 30,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 36,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/10.event-handlers/04.unquoted-inline.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/10.event-handlers/04.unquoted-inline.svelte.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "() => fn(event)",
+    "text": "() => fn(event)",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 30,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 31
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 42,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 43
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/10.event-handlers/05.double-quoted-inline.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/10.event-handlers/05.double-quoted-inline.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "() => fn(event)",
+    "text": "() => fn(event)",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 44
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 44,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 45
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/10.event-handlers/06.single-quoted-inline.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/10.event-handlers/06.single-quoted-inline.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "() => fn(event)",
+    "text": "() => fn(event)",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 44
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 44,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 45
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/01.no-expression.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 27,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/02.unquoted-identifier.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 133,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 42
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 135,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 44
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 135,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 44
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/05.unquoted-object.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 44
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 47
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 47
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 47,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 48
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/06.double-quoted-object.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 43
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 43
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 43
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 43
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 44
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 46
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 49
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 49
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 49,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 50
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/01.directive-identifier/07.single-quoted-object.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 22,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 23,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 43
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 43
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 43
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 43
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 44
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 46
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 49
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 49
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 49,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 50
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/02.expression/01.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/02.expression/01.unquoted-identifier.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 149,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 42
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/02.expression/02.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/02.expression/02.double-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 151,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 44
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/02.expression/03.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/01.bidirectional/02.expression/03.single-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 43
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 151,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 44
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/01.no-expression.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 19,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 20
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/02.unquoted-identifier.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 125,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 34
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 127,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 36
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 127,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 36
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/05.unquoted-object.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 25
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 30,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 31
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 39,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 40
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/06.double-quoted-object.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 41,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 42
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/02.in/01.directive-identifier/07.single-quoted-object.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 41,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 42
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/02.in/02.expression/01.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/02.in/02.expression/01.unquoted-identifier.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 141,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 34
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/02.in/02.expression/02.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/02.in/02.expression/02.double-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 143,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 36
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/02.in/02.expression/03.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/02.in/02.expression/03.single-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 143,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 36
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/01.no-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/01.no-expression.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 19,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 20,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/02.unquoted-identifier.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 126,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 35
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 128,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 90,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 128,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/05.unquoted-object.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 25,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 26
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 40,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 41
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/06.double-quoted-object.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 42,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 43
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/03.out/01.directive-identifier/07.single-quoted-object.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 5,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 8,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 9,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 13,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "duration",
+    "text": "duration",
+    "offset": 18,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 19
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 26,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 27
+  },
+  {
+    "type": "_brace_contents",
+    "value": ": 300",
+    "text": ": 300",
+    "offset": 27,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 28
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 33
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 34
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 42,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 43
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/03.out/02.expression/01.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/03.out/02.expression/01.unquoted-identifier.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 31
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 34
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 142,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 35
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/03.out/02.expression/02.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/03.out/02.expression/02.double-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 144,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/11.transitions/03.out/02.expression/03.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/11.transitions/03.out/02.expression/03.single-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration});\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 106,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 144,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/12.raw-html-tag/01.single-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/12.raw-html-tag/01.single-identifier.svelte.json
@@ -1,0 +1,56 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "raw_html_start",
+    "value": "@html",
+    "text": "@html",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_raw_html_expression",
+    "value": " html",
+    "text": " html",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 11,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 12,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 13
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 12,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 13
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/12.raw-html-tag/02.binary-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/12.raw-html-tag/02.binary-expression.svelte.json
@@ -1,0 +1,56 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "raw_html_start",
+    "value": "@html",
+    "text": "@html",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_raw_html_expression",
+    "value": " html + id",
+    "text": " html + id",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 17,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 17,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 18
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/12.raw-html-tag/03.template-expression.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/12.raw-html-tag/03.template-expression.svelte.json
@@ -1,0 +1,92 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "raw_html_start",
+    "value": "@html",
+    "text": "@html",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_raw_html_expression",
+    "value": " `<div>$",
+    "text": " `<div>$",
+    "offset": 6,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 7
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_brace_contents",
+    "value": "value",
+    "text": "value",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_raw_html_expression",
+    "value": "</div>`",
+    "text": "</div>`",
+    "offset": 21,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 28,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 29,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 29,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/13.debug-tag/01.single-identifier.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/13.debug-tag/01.single-identifier.svelte.json
@@ -1,0 +1,56 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "debug_start",
+    "value": "@debug",
+    "text": "@debug",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_debug_identifiers",
+    "value": " active",
+    "text": " active",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 14,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 15,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 15,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 16
+  }
+]

--- a/test/baselines/template-lexer/08.undefined/13.debug-tag/02.multiple-identifiers.svelte.json
+++ b/test/baselines/template-lexer/08.undefined/13.debug-tag/02.multiple-identifiers.svelte.json
@@ -1,0 +1,56 @@
+[
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "debug_start",
+    "value": "@debug",
+    "text": "@debug",
+    "offset": 1,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 2
+  },
+  {
+    "type": "_debug_identifiers",
+    "value": " active, checked, id, number",
+    "text": " active, checked, id, number",
+    "offset": 7,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 36
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 36,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/09.unused/01.value/01.empty-template.svelte.json
+++ b/test/baselines/template-lexer/09.unused/01.value/01.empty-template.svelte.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"some value\";\n",
+    "text": "\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 48,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/09.unused/01.value/02.tag-content.svelte.json
+++ b/test/baselines/template-lexer/09.unused/01.value/02.tag-content.svelte.json
@@ -1,0 +1,128 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"some value\";\n",
+    "text": "\n  const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 48,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "value",
+    "text": "value",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 66,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  }
+]

--- a/test/baselines/template-lexer/09.unused/01.value/03.unquoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/09.unused/01.value/03.unquoted-attribute.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"value\";\n",
+    "text": "\n  const value = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 43,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "value",
+    "text": "value",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 66,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/09.unused/01.value/04.double-quoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/09.unused/01.value/04.double-quoted-attribute.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"value\";\n",
+    "text": "\n  const value = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 43,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "value",
+    "text": "value",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 68,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/09.unused/01.value/05.single-quoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/09.unused/01.value/05.single-quoted-attribute.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"value\";\n",
+    "text": "\n  const value = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 43,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "value",
+    "text": "value",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "value",
+    "text": "value",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 68,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/09.unused/01.value/06.content-mustache-string.svelte.json
+++ b/test/baselines/template-lexer/09.unused/01.value/06.content-mustache-string.svelte.json
@@ -1,0 +1,182 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"value\";\n",
+    "text": "\n  const value = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 43,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "value",
+    "text": "value",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 65,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/09.unused/01.value/07.unquoted-attribute-mustache.svelte.json
+++ b/test/baselines/template-lexer/09.unused/01.value/07.unquoted-attribute-mustache.svelte.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"value\";\n",
+    "text": "\n  const value = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 43,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "value",
+    "text": "value",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "value",
+    "text": "value",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 70,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/09.unused/01.value/08.double-quoted-attribute-mustache.svelte.json
+++ b/test/baselines/template-lexer/09.unused/01.value/08.double-quoted-attribute-mustache.svelte.json
@@ -1,0 +1,245 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"value\";\n",
+    "text": "\n  const value = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 43,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "value",
+    "text": "value",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "value",
+    "text": "value",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 72,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/09.unused/01.value/09.single-quoted-attribute-mustache.svelte.json
+++ b/test/baselines/template-lexer/09.unused/01.value/09.single-quoted-attribute-mustache.svelte.json
@@ -1,0 +1,245 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const value = \"value\";\n",
+    "text": "\n  const value = \"value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 34,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 43,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "input",
+    "text": "input",
+    "offset": 46,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "value",
+    "text": "value",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "value",
+    "text": "value",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": "/>",
+    "text": "/>",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 72,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/01.empty-template.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/01.empty-template.svelte.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 51,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/02.content.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/02.content.svelte.json
@@ -1,0 +1,128 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "$count",
+    "text": "$count",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 70,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 18
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/03.unquoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/03.unquoted-attribute.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "$count",
+    "text": "$count",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/04.double-quoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/04.double-quoted-attribute.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "$count",
+    "text": "$count",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/05.single-quoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/05.single-quoted-attribute.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "$count",
+    "text": "$count",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/06.content-mustache.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/06.content-mustache.svelte.json
@@ -1,0 +1,182 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "$count",
+    "text": "$count",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/07.unquoted-attribute-mustache.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/07.unquoted-attribute-mustache.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "$count",
+    "text": "$count",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 78,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/08.double-quoted-attribute-mustache.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/08.double-quoted-attribute-mustache.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "$count",
+    "text": "$count",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 80,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/09.single-quoted-attribute-mustache.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/01.imported/09.single-quoted-attribute-mustache.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {count} from \"./store\";\n",
+    "text": "\n  import {count} from \"./store\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "$count",
+    "text": "$count",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 80,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/01.empty-template.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/01.empty-template.svelte.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 110,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/02.content.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/02.content.svelte.json
@@ -1,0 +1,128 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "$count",
+    "text": "$count",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 129,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 18
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/03.unquoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/03.unquoted-attribute.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "$count",
+    "text": "$count",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 133,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/04.double-quoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/04.double-quoted-attribute.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "$count",
+    "text": "$count",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 135,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/05.single-quoted-attribute.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/05.single-quoted-attribute.svelte.json
@@ -1,0 +1,218 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_value",
+    "value": "$count",
+    "text": "$count",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 135,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/06.content-mustache.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/06.content-mustache.svelte.json
@@ -1,0 +1,182 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "$count",
+    "text": "$count",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 133,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/07.unquoted-attribute-mustache.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/07.unquoted-attribute-mustache.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "$count",
+    "text": "$count",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 137,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 26
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/08.double-quoted-attribute-mustache.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/08.double-quoted-attribute-mustache.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "$count",
+    "text": "$count",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 139,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/09.single-quoted-attribute-mustache.svelte.json
+++ b/test/baselines/template-lexer/09.unused/02.store-auto-subscription/02.self-declared/09.single-quoted-attribute-mustache.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "text": "\n  import {readable} from \"svelte/store\";\n\n  const number = 0,\n    store = readable(number);\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 110,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "id",
+    "text": "id",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 11
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "$count",
+    "text": "$count",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 139,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/09.unused/03.components/01.correctly-cased.svelte.json
+++ b/test/baselines/template-lexer/09.unused/03.components/01.correctly-cased.svelte.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 47,
+    "lineBreaks": 1,
+    "line": 3,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/09.unused/03.components/02.incorrectly-cased.svelte.json
+++ b/test/baselines/template-lexer/09.unused/03.components/02.incorrectly-cased.svelte.json
@@ -1,0 +1,119 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import foo from \"/.foo\";\n",
+    "text": "\n  import foo from \"/.foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 45,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "foo",
+    "text": "foo",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_tag_name",
+    "value": "foo",
+    "text": "foo",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 58,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 12
+  }
+]

--- a/test/baselines/template-lexer/09.unused/04.actions/01.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/04.actions/01.unquoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "text": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 92,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "options",
+    "text": "options",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 132,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/09.unused/04.actions/02.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/04.actions/02.double-quoted-identifier.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "text": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 92,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "options",
+    "text": "options",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 31
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 134,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 41
+  }
+]

--- a/test/baselines/template-lexer/09.unused/04.actions/03.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/04.actions/03.single-quoted-identifier.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "text": "\n  const action = (node) => node.remove(),\n    options = {\"option\": true};\n",
+    "offset": 8,
+    "lineBreaks": 3,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 92,
+    "lineBreaks": 2,
+    "line": 4,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "use",
+    "text": "use",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "action",
+    "text": "action",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "options",
+    "text": "options",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 27
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 31
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 35
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 37
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 40
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 134,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 41
+  }
+]

--- a/test/baselines/template-lexer/09.unused/05.animation/01.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/05.animation/01.unquoted-identifier.svelte.json
@@ -1,0 +1,461 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 181,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 213,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 217,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 220,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 228,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 229,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 234,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 235,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 235,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 247,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 34
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 248,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 35
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 252,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 255,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 255,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 256,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 43
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 257,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 258,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 263,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 264,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 264,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/05.animation/02.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/05.animation/02.double-quoted-identifier.svelte.json
@@ -1,0 +1,479 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 181,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 213,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 217,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 220,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 228,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 229,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 234,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 235,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 237,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 248,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 35
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 37
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 38
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 38
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 38
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 38
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 252,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 39
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 254,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 41
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 257,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 44
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 257,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 258,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 45
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 259,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 260,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 265,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 266,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 266,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/05.animation/03.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/05.animation/03.single-quoted-identifier.svelte.json
@@ -1,0 +1,479 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300},\n    titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 181,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 199,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 200,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 206,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 207,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 213,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 217,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 220,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "animate",
+    "text": "animate",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 228,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 229,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 233,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 234,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 235,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 236,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 237,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 248,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 35
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 249,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 36
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 37
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 250,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 38
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 38
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 38
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 251,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 38
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 252,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 39
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 254,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 41
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 257,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 44
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 257,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 258,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 45
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 259,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 260,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 265,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 266,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 266,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/06.class/01.attribute-expression.svelte.json
+++ b/test/baselines/template-lexer/09.unused/06.class/01.attribute-expression.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const active = \"active\";\n",
+    "text": "\n  const active = \"active\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 36,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 45,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "active",
+    "text": "active",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 79,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 33
+  }
+]

--- a/test/baselines/template-lexer/09.unused/06.class/02.directive-unquoted.svelte.json
+++ b/test/baselines/template-lexer/09.unused/06.class/02.directive-unquoted.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const active = true;\n",
+    "text": "\n  const active = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 41,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "active",
+    "text": "active",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "active",
+    "text": "active",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 40
+  }
+]

--- a/test/baselines/template-lexer/09.unused/06.class/03.directive-double-quoted.svelte.json
+++ b/test/baselines/template-lexer/09.unused/06.class/03.directive-double-quoted.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const active = true;\n",
+    "text": "\n  const active = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 41,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "active",
+    "text": "active",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "active",
+    "text": "active",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 84,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 42
+  }
+]

--- a/test/baselines/template-lexer/09.unused/06.class/04.directive-single-quoted.svelte.json
+++ b/test/baselines/template-lexer/09.unused/06.class/04.directive-single-quoted.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const active = true;\n",
+    "text": "\n  const active = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 32,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 41,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 47,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "class",
+    "text": "class",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "active",
+    "text": "active",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "active",
+    "text": "active",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 84,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 42
+  }
+]

--- a/test/baselines/template-lexer/09.unused/07.event-handlers/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/07.event-handlers/02.unquoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const handler = (event) => event.target.remove();\n",
+    "text": "\n  const handler = (event) => event.target.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 70,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "handler",
+    "text": "handler",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 108,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/09.unused/07.event-handlers/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/07.event-handlers/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const handler = (event) => event.target.remove();\n",
+    "text": "\n  const handler = (event) => event.target.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 70,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "handler",
+    "text": "handler",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 110,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/09.unused/07.event-handlers/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/07.event-handlers/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const handler = (event) => event.target.remove();\n",
+    "text": "\n  const handler = (event) => event.target.remove();\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 70,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "handler",
+    "text": "handler",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 110,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/09.unused/07.event-handlers/05.unquoted-inline.svelte.json
+++ b/test/baselines/template-lexer/09.unused/07.event-handlers/05.unquoted-inline.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {fn} from \"somewhere\";\n",
+    "text": "\n  import {fn} from \"somewhere\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 50,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "(event) => fn()",
+    "text": "(event) => fn()",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 42
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 42
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 43
+  }
+]

--- a/test/baselines/template-lexer/09.unused/07.event-handlers/06.double-quoted-inline.svelte.json
+++ b/test/baselines/template-lexer/09.unused/07.event-handlers/06.double-quoted-inline.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {fn} from \"somewhere\";\n",
+    "text": "\n  import {fn} from \"somewhere\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 50,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "(event) => fn()",
+    "text": "(event) => fn()",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 96,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 45
+  }
+]

--- a/test/baselines/template-lexer/09.unused/07.event-handlers/07.single-quoted-inline.svelte.json
+++ b/test/baselines/template-lexer/09.unused/07.event-handlers/07.single-quoted-inline.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {fn} from \"somewhere\";\n",
+    "text": "\n  import {fn} from \"somewhere\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 50,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "(event) => fn()",
+    "text": "(event) => fn()",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_body",
+    "value": "Text",
+    "text": "Text",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 96,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 45
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/01.empty-content/01.shorthand.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/01.empty-content/01.shorthand.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 69,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 21
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/01.empty-content/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/01.empty-content/02.unquoted-identifier.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 28
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/01.empty-content/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/01.empty-content/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 78,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/01.empty-content/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/01.empty-content/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 78,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/01.empty-content/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/01.empty-content/05.unquoted-object.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 85,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/01.empty-content/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/01.empty-content/06.double-quoted-object.svelte.json
@@ -1,0 +1,299 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 87,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/01.empty-content/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/01.empty-content/07.single-quoted-object.svelte.json
@@ -1,0 +1,299 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 87,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/01.empty-content/08.unquoted-array.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/01.empty-content/08.unquoted-array.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 64,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 91,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/01.empty-content/09.double-quoted-array.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/01.empty-content/09.double-quoted-array.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 65,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 93,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 11
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/01.empty-content/10.single-quoted-array.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/01.empty-content/10.single-quoted-array.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 65,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 93,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 11
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/02.plain-content/01.shorthand.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/02.plain-content/01.shorthand.svelte.json
@@ -1,0 +1,209 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "item",
+    "text": "item",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 19
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 73,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 25
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/02.plain-content/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/02.plain-content/02.unquoted-identifier.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "item",
+    "text": "item",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 80,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 32
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/02.plain-content/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/02.plain-content/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "item",
+    "text": "item",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 34
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/02.plain-content/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/02.plain-content/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "item",
+    "text": "item",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 34
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/02.plain-content/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/02.plain-content/05.unquoted-object.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "#index: name",
+    "text": "#index: name",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 43
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 45
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 48
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 48
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 97,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 49
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/02.plain-content/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/02.plain-content/06.double-quoted-object.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "#index: name",
+    "text": "#index: name",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 45
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 47
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 50
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 50
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 51
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/02.plain-content/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/02.plain-content/07.single-quoted-object.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "#index: name",
+    "text": "#index: name",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 45
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 47
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 50
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 50
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 51
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/02.plain-content/08.unquoted-array.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/02.plain-content/08.unquoted-array.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 64,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_body",
+    "value": "#index: name",
+    "text": "#index: name",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 103,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 22
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/02.plain-content/09.double-quoted-array.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/02.plain-content/09.double-quoted-array.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 65,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_body",
+    "value": "#index: name",
+    "text": "#index: name",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 105,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/02.plain-content/10.single-quoted-array.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/02.plain-content/10.single-quoted-array.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 65,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_body",
+    "value": "#index: name",
+    "text": "#index: name",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 105,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/01.shorthand.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/01.shorthand.svelte.json
@@ -1,0 +1,263 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "item",
+    "text": "item",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 77,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/02.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/02.unquoted-identifier.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 20
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "item",
+    "text": "item",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 84,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 36
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/03.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/03.double-quoted-identifier.svelte.json
@@ -1,0 +1,344 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "item",
+    "text": "item",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 86,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 38
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/04.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/04.single-quoted-identifier.svelte.json
@@ -1,0 +1,344 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "item",
+    "text": "item",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 25
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "item",
+    "text": "item",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 26
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 86,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 38
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/05.unquoted-object.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/05.unquoted-object.svelte.json
@@ -1,0 +1,425 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "index",
+    "text": "index",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 39
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 40
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 43
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 44
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "name",
+    "text": "name",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 45
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 49
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 50
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 51
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 51
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 53
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 56
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 56
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 105,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 57
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/06.double-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/06.double-quoted-object.svelte.json
@@ -1,0 +1,443 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "index",
+    "text": "index",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 42
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 43
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 43
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 45
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 46
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 46
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "name",
+    "text": "name",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 47
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 51
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 52
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 53
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 53
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 55
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 58
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 58
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 107,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 59
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/07.single-quoted-object.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/07.single-quoted-object.svelte.json
@@ -1,0 +1,443 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "index, name",
+    "text": "index, name",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 33
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 34
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 35
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "index",
+    "text": "index",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 36
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 41
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 42
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 43
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 43
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 45
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 46
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 46
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "name",
+    "text": "name",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 47
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 51
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 52
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 53
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 53
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 55
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 58
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 58
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 107,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 59
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/08.unquoted-array.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/08.unquoted-array.svelte.json
@@ -1,0 +1,407 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 64,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "index",
+    "text": "index",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "name",
+    "text": "name",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 111,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/09.double-quoted-array.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/09.double-quoted-array.svelte.json
@@ -1,0 +1,425 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 65,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "index",
+    "text": "index",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "name",
+    "text": "name",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 113,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 31
+  }
+]

--- a/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/10.single-quoted-array.svelte.json
+++ b/test/baselines/template-lexer/09.unused/08.let/03.mustache-content/10.single-quoted-array.svelte.json
@@ -1,0 +1,425 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {Foo} from \"./foo\";\n",
+    "text": "\n  import {Foo} from \"./foo\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 38,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 47,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_component_identifier",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "let",
+    "text": "let",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "item",
+    "text": "item",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "[\n  index,\n  name\n]",
+    "text": "[\n  index,\n  name\n]",
+    "offset": 65,
+    "lineBreaks": 3,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_body",
+    "value": "#",
+    "text": "#",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "index",
+    "text": "index",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": ": ",
+    "text": ": ",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "name",
+    "text": "name",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "html_tag_name",
+    "value": "Foo",
+    "text": "Foo",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 113,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 31
+  }
+]

--- a/test/baselines/template-lexer/09.unused/09.transitions/01.bidirectional/01.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/09.transitions/01.bidirectional/01.unquoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 43
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 196,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 44
+  }
+]

--- a/test/baselines/template-lexer/09.unused/09.transitions/01.bidirectional/02.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/09.transitions/01.bidirectional/02.double-quoted-identifier.svelte.json
@@ -1,0 +1,299 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 42
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 45
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 45
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 198,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 46
+  }
+]

--- a/test/baselines/template-lexer/09.unused/09.transitions/01.bidirectional/03.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/09.transitions/01.bidirectional/03.single-quoted-identifier.svelte.json
@@ -1,0 +1,299 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "transition",
+    "text": "transition",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 21
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 39
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 40
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 42
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 45
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 197,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 45
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 198,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 46
+  }
+]

--- a/test/baselines/template-lexer/09.unused/09.transitions/02.in/01.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/09.transitions/02.in/01.unquoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 188,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 36
+  }
+]

--- a/test/baselines/template-lexer/09.unused/09.transitions/02.in/02.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/09.transitions/02.in/02.double-quoted-identifier.svelte.json
@@ -1,0 +1,299 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 190,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 38
+  }
+]

--- a/test/baselines/template-lexer/09.unused/09.transitions/02.in/03.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/09.transitions/02.in/03.single-quoted-identifier.svelte.json
@@ -1,0 +1,299 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "in",
+    "text": "in",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 34
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 37
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 190,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 38
+  }
+]

--- a/test/baselines/template-lexer/09.unused/09.transitions/03.out/01.unquoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/09.transitions/03.out/01.unquoted-identifier.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 33
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 36
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 189,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 37
+  }
+]

--- a/test/baselines/template-lexer/09.unused/09.transitions/03.out/02.double-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/09.transitions/03.out/02.double-quoted-identifier.svelte.json
@@ -1,0 +1,299 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 191,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/09.unused/09.transitions/03.out/03.single-quoted-identifier.svelte.json
+++ b/test/baselines/template-lexer/09.unused/09.transitions/03.out/03.single-quoted-identifier.svelte.json
@@ -1,0 +1,299 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "text": "\n  const duration300 = 300,\n    fade = (node, {duration = duration300}) => ({duration}),\n    fadeOptions = {\"duration\": duration300};\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 151,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "out",
+    "text": "out",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "fade",
+    "text": "fade",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_left_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_double_string_contents",
+    "value": "fadeOptions",
+    "text": "fadeOptions",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_right_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "html_attribute_single_quote",
+    "value": "'",
+    "text": "'",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 31
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 32
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 33
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 35
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 38
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 191,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 39
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/01.identifier-context/01.context.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/01.identifier-context/01.context.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 75,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 95,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 103,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/01.identifier-context/02.index.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/01.identifier-context/02.index.svelte.json
@@ -1,0 +1,353 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 99,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 107,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/01.identifier-context/03.context-index.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/01.identifier-context/03.context-index.svelte.json
@@ -1,0 +1,317 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title",
+    "text": "title",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 110,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/01.identifier-context/04.key-identifier-uses-context.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/01.identifier-context/04.key-identifier-uses-context.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "title",
+    "text": "title",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 110,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/01.identifier-context/05.key-expression-uses-context.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/01.identifier-context/05.key-expression-uses-context.svelte.json
@@ -1,0 +1,317 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\"A Blog Post\"];\n",
+    "text": "\n  const posts = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 42,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 51,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "title ",
+    "text": "title ",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_each_key",
+    "value": "title",
+    "text": "title",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 24
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 30
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 83,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 31
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 103,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 111,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/02.object-context/01.context.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/02.object-context/01.context.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id",
+    "text": "id",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 108,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 128,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 136,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/02.object-context/02.index.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/02.object-context/02.index.svelte.json
@@ -1,0 +1,371 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id",
+    "text": "id",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 115,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 132,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 140,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/02.object-context/03.context-index.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/02.object-context/03.context-index.svelte.json
@@ -1,0 +1,335 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id",
+    "text": "id",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 115,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 135,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 143,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/02.object-context/04.key-identifier-uses-context.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/02.object-context/04.key-identifier-uses-context.svelte.json
@@ -1,0 +1,335 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id",
+    "text": "id",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 112,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 132,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 140,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/02.object-context/05.key-expression-uses-context.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/02.object-context/05.key-expression-uses-context.svelte.json
@@ -1,0 +1,344 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "text": "\n  const posts = [\n    {\"id\": 1,\n      \"title\": \"A Blog Post\"}\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 85,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_left_brace",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_brace_contents",
+    "value": "id",
+    "text": "id",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_right_brace",
+    "value": "}",
+    "text": "}",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 21
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_each_key",
+    "value": "id",
+    "text": "id",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 113,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 133,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 141,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/03.array-context/01.context.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/03.array-context/01.context.svelte.json
@@ -1,0 +1,308 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "id",
+    "text": "id",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 21
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 21
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 136,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 156,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 164,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/03.array-context/02.index.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/03.array-context/02.index.svelte.json
@@ -1,0 +1,371 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "id",
+    "text": "id",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 21
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 21
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 143,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "title",
+    "text": "title",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 160,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 168,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/03.array-context/03.context-index.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/03.array-context/03.context-index.svelte.json
@@ -1,0 +1,335 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "id",
+    "text": "id",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 21
+  },
+  {
+    "type": "each_comma",
+    "value": ",",
+    "text": ",",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 21
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "each_index_identifier",
+    "value": "index",
+    "text": "index",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 143,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 163,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 171,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/03.array-context/04.key-identifier-uses-context.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/03.array-context/04.key-identifier-uses-context.svelte.json
@@ -1,0 +1,335 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "id",
+    "text": "id",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 21
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "each_key_ampersat",
+    "value": "@",
+    "text": "@",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "each_key_identifier",
+    "value": "id",
+    "text": "id",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 140,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 160,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 168,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/10.each/03.array-context/05.key-expression-uses-context.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/03.array-context/05.key-expression-uses-context.svelte.json
@@ -1,0 +1,344 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "text": "\n  const postId = 1,\n    posts = [\n      [\n        postId,\n        \"A Blog Post\"\n      ]\n    ];\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_left_bracket",
+    "value": "[",
+    "text": "[",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_bracket_contents",
+    "value": "id",
+    "text": "id",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "_right_bracket",
+    "value": "]",
+    "text": "]",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 21
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "each_key_start",
+    "value": "(",
+    "text": "(",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "_each_key",
+    "value": "id",
+    "text": "id",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "each_key_end",
+    "value": ")",
+    "text": ")",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 25
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 141,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Some Title",
+    "text": "Some Title",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 161,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 169,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/09.unused/11.await/01.full-catch/01.result.svelte.json
+++ b/test/baselines/template-lexer/09.unused/11.await/01.full-catch/01.result.svelte.json
@@ -1,0 +1,605 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting...",
+    "text": "Waiting...",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result",
+    "text": "Got result",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 137,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 152,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 180,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 189,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/09.unused/11.await/01.full-catch/02.error.svelte.json
+++ b/test/baselines/template-lexer/09.unused/11.await/01.full-catch/02.error.svelte.json
@@ -1,0 +1,605 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting...",
+    "text": "Waiting...",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 147,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 162,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error",
+    "text": "Got error",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 15
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 181,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 190,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/09.unused/11.await/01.full-catch/03.result-error.svelte.json
+++ b/test/baselines/template-lexer/09.unused/11.await/01.full-catch/03.result-error.svelte.json
@@ -1,0 +1,560 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting...",
+    "text": "Waiting...",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result",
+    "text": "Got result",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 137,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 152,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error",
+    "text": "Got error",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 15
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 171,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 180,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/09.unused/11.await/02.full-no-catch/01.result.svelte.json
+++ b/test/baselines/template-lexer/09.unused/11.await/02.full-no-catch/01.result.svelte.json
@@ -1,0 +1,407 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting...",
+    "text": "Waiting...",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result",
+    "text": "Got result",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 137,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/09.unused/11.await/03.compact-catch/01.result.svelte.json
+++ b/test/baselines/template-lexer/09.unused/11.await/03.compact-catch/01.result.svelte.json
@@ -1,0 +1,479 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise ",
+    "text": "promise ",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "await_compact_then",
+    "value": "then",
+    "text": "then",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_await_then_compact_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result",
+    "text": "Got result",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 114,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 129,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 157,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 166,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/09.unused/11.await/03.compact-catch/02.error.svelte.json
+++ b/test/baselines/template-lexer/09.unused/11.await/03.compact-catch/02.error.svelte.json
@@ -1,0 +1,479 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise ",
+    "text": "promise ",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "await_compact_then",
+    "value": "then",
+    "text": "then",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_await_then_compact_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 139,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error",
+    "text": "Got error",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 158,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 167,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/09.unused/11.await/03.compact-catch/03.result-error.svelte.json
+++ b/test/baselines/template-lexer/09.unused/11.await/03.compact-catch/03.result-error.svelte.json
@@ -1,0 +1,434 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise ",
+    "text": "promise ",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "await_compact_then",
+    "value": "then",
+    "text": "then",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_await_then_compact_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result",
+    "text": "Got result",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 114,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 129,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error",
+    "text": "Got error",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 148,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 157,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/09.unused/11.await/04.compact-no-catch/01.result.svelte.json
+++ b/test/baselines/template-lexer/09.unused/11.await/04.compact-no-catch/01.result.svelte.json
@@ -1,0 +1,281 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise ",
+    "text": "promise ",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "await_compact_then",
+    "value": "then",
+    "text": "then",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_await_then_compact_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result",
+    "text": "Got result",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 114,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 123,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/01.disable/01.script-block-all.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/01.disable/01.script-block-all.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  /* eslint-disable */\n  const first = 2;\n\n  const posts = [];\n",
+    "text": "\n  /* eslint-disable */\n  const first = 2;\n\n  const posts = [];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 81,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 101,
+    "lineBreaks": 2,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 135,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 162,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 170,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/01.disable/02.template-all.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/01.disable/02.template-all.svelte.json
@@ -1,0 +1,488 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable ",
+    "text": " eslint-disable ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 23,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  const posts = [];\n",
+    "text": "\n  const first = 2;\n\n  const posts = [];\n",
+    "offset": 32,
+    "lineBreaks": 4,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 82,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 102,
+    "lineBreaks": 2,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 136,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 163,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 171,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/01.disable/03.script-block-specific.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/01.disable/03.script-block-specific.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  /* eslint-disable one-var, camelcase */\n  const first = 2;\n\n  const posts = [];\n",
+    "text": "\n  /* eslint-disable one-var, camelcase */\n  const first = 2;\n\n  const posts = [];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 100,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 120,
+    "lineBreaks": 2,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 154,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 181,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 189,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/01.disable/04.template-specific.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/01.disable/04.template-specific.svelte.json
@@ -1,0 +1,488 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable one-var, camelcase ",
+    "text": " eslint-disable one-var, camelcase ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 42,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 43
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  const posts = [];\n",
+    "text": "\n  const first = 2;\n\n  const posts = [];\n",
+    "offset": 51,
+    "lineBreaks": 4,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 101,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 121,
+    "lineBreaks": 2,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 155,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 182,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 190,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/02.enable/01.script-block-all.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/02.enable/01.script-block-all.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  /* eslint-disable */\n  const first = 2;\n\n  const posts = [];\n  /* eslint-enable */\n",
+    "text": "\n  /* eslint-disable */\n  const first = 2;\n\n  const posts = [];\n  /* eslint-enable */\n",
+    "offset": 8,
+    "lineBreaks": 6,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 103,
+    "lineBreaks": 2,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 123,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 157,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 183,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 184,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 192,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/02.enable/02.template-all.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/02.enable/02.template-all.svelte.json
@@ -1,0 +1,524 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable ",
+    "text": " eslint-disable ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 21
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 23,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 24
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 24,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  const posts = [];\n",
+    "text": "\n  const first = 2;\n\n  const posts = [];\n",
+    "offset": 32,
+    "lineBreaks": 4,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 82,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 102,
+    "lineBreaks": 2,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 136,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-enable ",
+    "text": " eslint-enable ",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 159,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 186,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 194,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/02.enable/03.script-block-specific.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/02.enable/03.script-block-specific.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  /* eslint-disable one-var, camelcase */\n  const first = 2;\n  /* eslint-enable camelcase */\n\n  const posts = [];\n",
+    "text": "\n  /* eslint-disable one-var, camelcase */\n  const first = 2;\n  /* eslint-enable camelcase */\n\n  const posts = [];\n",
+    "offset": 8,
+    "lineBreaks": 6,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 132,
+    "lineBreaks": 2,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 152,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 167,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 186,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 208,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 211,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 213,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 214,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 215,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 220,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 221,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/02.enable/04.template-specific.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/02.enable/04.template-specific.svelte.json
@@ -1,0 +1,524 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable one-var, camelcase ",
+    "text": " eslint-disable one-var, camelcase ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 39,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 40
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 42,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 43
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  const posts = [];\n",
+    "text": "\n  const first = 2;\n\n  const posts = [];\n",
+    "offset": 51,
+    "lineBreaks": 4,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 101,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 121,
+    "lineBreaks": 2,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 155,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-enable camelcase",
+    "text": " eslint-enable camelcase",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 187,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 32
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 193,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 194,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 209,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 210,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 212,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 213,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 214,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 215,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 216,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 221,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 222,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 222,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/03.disable-next-line/01.script-block-all.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/03.disable-next-line/01.script-block-all.svelte.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  // eslint-disable-next-line\n  const posts = [];\n\n  export let snake_case = \"a value\";\n",
+    "text": "\n  const first = 2;\n\n  // eslint-disable-next-line\n  const posts = [];\n\n  export let snake_case = \"a value\";\n",
+    "offset": 8,
+    "lineBreaks": 7,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 126,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/03.disable-next-line/02.template-all.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/03.disable-next-line/02.template-all.svelte.json
@@ -1,0 +1,488 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  const posts = [];\n",
+    "text": "\n  const first = 2;\n\n  const posts = [];\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 58,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 78,
+    "lineBreaks": 2,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable-next-line ",
+    "text": " eslint-disable-next-line ",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 31
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 113,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 34
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 173,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 181,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/03.disable-next-line/03.script-block-specific.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/03.disable-next-line/03.script-block-specific.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  /* eslint-disable-next-line one-var */\n  const posts = [];\n",
+    "text": "\n  const first = 2;\n\n  /* eslint-disable-next-line one-var */\n  const posts = [];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 99,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 119,
+    "lineBreaks": 2,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 153,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 157,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 180,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 187,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 188,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 188,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/03.disable-next-line/04.template-specific.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/03.disable-next-line/04.template-specific.svelte.json
@@ -1,0 +1,488 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  const posts = [];\n",
+    "text": "\n  const first = 2;\n\n  const posts = [];\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 58,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 78,
+    "lineBreaks": 2,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable-next-line camelcase ",
+    "text": " eslint-disable-next-line camelcase ",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 123,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 44
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 156,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 181,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 182,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 183,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 184,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 191,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 191,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/04.disable-line/01.script-block-all.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/04.disable-line/01.script-block-all.svelte.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  const posts = []; // eslint-disable-line\n\n  export let snake_case = \"a value\";\n",
+    "text": "\n  const first = 2;\n\n  const posts = []; // eslint-disable-line\n\n  export let snake_case = \"a value\";\n",
+    "offset": 8,
+    "lineBreaks": 6,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 119,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/04.disable-line/02.template-all.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/04.disable-line/02.template-all.svelte.json
@@ -1,0 +1,488 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  const posts = [];\n",
+    "text": "\n  const first = 2;\n\n  const posts = [];\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 58,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 78,
+    "lineBreaks": 2,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 112,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": " ",
+    "text": " ",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 28
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable-line ",
+    "text": " eslint-disable-line ",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 53
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 168,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 56
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 176,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 176,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/04.disable-line/03.script-block-specific.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/04.disable-line/03.script-block-specific.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  const posts = []; // eslint-disable-line one-var\n",
+    "text": "\n  const first = 2;\n\n  const posts = []; // eslint-disable-line one-var\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 89,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 109,
+    "lineBreaks": 2,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 143,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 170,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 178,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/04.disable-line/04.template-specific.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/04.disable-line/04.template-specific.svelte.json
@@ -1,0 +1,488 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const first = 2;\n\n  const posts = [];\n",
+    "text": "\n  const first = 2;\n\n  const posts = [];\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 58,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "first",
+    "text": "first",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 78,
+    "lineBreaks": 2,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "posts ",
+    "text": "posts ",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_each_context",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 32
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 112,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 33
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "snake_case_post",
+    "text": "snake_case_post",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 23
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 23
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 25
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 26
+  },
+  {
+    "type": "_body",
+    "value": " ",
+    "text": " ",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 28
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable-line camelcase ",
+    "text": " eslint-disable-line camelcase ",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 32
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 175,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 63
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 178,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 66
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 180,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 186,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 186,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/05.globals/01.script-block.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/05.globals/01.script-block.svelte.json
@@ -1,0 +1,416 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  /* globals id */\n\n  const handler = function handler (event) {\n\n    event.target.id = id.create();\n\n  };\n",
+    "text": "\n  /* globals id */\n\n  const handler = function handler (event) {\n\n    event.target.id = id.create();\n\n  };\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 125,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 19
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "handler",
+    "text": "handler",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "Set ID",
+    "text": "Set ID",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 44
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 171,
+    "lineBreaks": 2,
+    "line": 11,
+    "col": 45
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id.current",
+    "text": "id.current",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 18
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 18
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 20
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 196,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/10.eslint-directives/05.globals/02.template.svelte.json
+++ b/test/baselines/template-lexer/10.eslint-directives/05.globals/02.template.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " globals id ",
+    "text": " globals id ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 16,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 19,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 20
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 20,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const handler = function handler (event) {\n\n    event.target.id = id.create();\n\n  };\n",
+    "text": "\n  const handler = function handler (event) {\n\n    event.target.id = id.create();\n\n  };\n",
+    "offset": 28,
+    "lineBreaks": 6,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 125,
+    "lineBreaks": 2,
+    "line": 8,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 9
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 9
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 19
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 20
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "handler",
+    "text": "handler",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 20
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "Set ID",
+    "text": "Set ID",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 44
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 171,
+    "lineBreaks": 2,
+    "line": 10,
+    "col": 45
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 173,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 174,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 177,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "id.current",
+    "text": "id.current",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 189,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 17
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 18
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 190,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 18
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 192,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 20
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 195,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 196,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 24
+  }
+]

--- a/test/baselines/template-lexer/11.indent/01.script-block/01.top-level-dedent.svelte.json
+++ b/test/baselines/template-lexer/11.indent/01.script-block/01.top-level-dedent.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\nconst value = \"some value\";\n",
+    "text": "\nconst value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 37,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 46,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 49,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 66,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 19
+  }
+]

--- a/test/baselines/template-lexer/11.indent/01.script-block/02.top-level-indent-further.svelte.json
+++ b/test/baselines/template-lexer/11.indent/01.script-block/02.top-level-indent-further.svelte.json
@@ -1,0 +1,164 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n    const value = \"some value\";\n",
+    "text": "\n    const value = \"some value\";\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 41,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 50,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 52,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 53,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "value",
+    "text": "value",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 12
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 70,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 19
+  }
+]

--- a/test/baselines/template-lexer/11.indent/01.script-block/03.function-dedent.svelte.json
+++ b/test/baselines/template-lexer/11.indent/01.script-block/03.function-dedent.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  /* eslint-disable func-style */\n\n  function handler (event) {\n\n  event.target.remove();\n\n  }\n",
+    "text": "\n  /* eslint-disable func-style */\n\n  function handler (event) {\n\n  event.target.remove();\n\n  }\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 113,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 19
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "handler",
+    "text": "handler",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "Remove",
+    "text": "Remove",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 44
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 159,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 45
+  }
+]

--- a/test/baselines/template-lexer/11.indent/01.script-block/04.function-dedent-further.svelte.json
+++ b/test/baselines/template-lexer/11.indent/01.script-block/04.function-dedent-further.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  /* eslint-disable func-style */\n\n  function handler (event) {\n\nevent.target.remove();\n\n  }\n",
+    "text": "\n  /* eslint-disable func-style */\n\n  function handler (event) {\n\nevent.target.remove();\n\n  }\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 111,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 19
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "handler",
+    "text": "handler",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "Remove",
+    "text": "Remove",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 44
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 157,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 45
+  }
+]

--- a/test/baselines/template-lexer/11.indent/01.script-block/05.function-indent-further.svelte.json
+++ b/test/baselines/template-lexer/11.indent/01.script-block/05.function-indent-further.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  /* eslint-disable func-style */\n\n  function handler (event) {\n\n      event.target.remove();\n\n  }\n",
+    "text": "\n  /* eslint-disable func-style */\n\n  function handler (event) {\n\n      event.target.remove();\n\n  }\n",
+    "offset": 8,
+    "lineBreaks": 8,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 117,
+    "lineBreaks": 2,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 8
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "_html_attribute_name_start",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "html_attribute_name",
+    "value": "on",
+    "text": "on",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 9
+  },
+  {
+    "type": "html_directive_colon",
+    "value": ":",
+    "text": ":",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 11
+  },
+  {
+    "type": "html_directive_identifier",
+    "value": "click",
+    "text": "click",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 12
+  },
+  {
+    "type": "_html_directive_identifier_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "_html_attribute_name_end",
+    "value": "",
+    "text": "",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_equal",
+    "value": "=",
+    "text": "=",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 17
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 19
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "handler",
+    "text": "handler",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 20
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 27
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "html_attribute_double_quote",
+    "value": "\"",
+    "text": "\"",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 28
+  },
+  {
+    "type": "_html_attribute_value_end",
+    "value": "",
+    "text": "",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "Remove",
+    "text": "Remove",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 30
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 36
+  },
+  {
+    "type": "html_tag_name",
+    "value": "button",
+    "text": "button",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 38
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 44
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 44
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 163,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 45
+  }
+]

--- a/test/baselines/template-lexer/11.indent/01.script-block/06.object-dedent.svelte.json
+++ b/test/baselines/template-lexer/11.indent/01.script-block/06.object-dedent.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const props = {\n  \"id\": \"some_id\"\n  };\n",
+    "text": "\n  const props = {\n  \"id\": \"some_id\"\n  };\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 50,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 59,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "...props",
+    "text": "...props",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 83,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/11.indent/01.script-block/07.object-dedent-further.svelte.json
+++ b/test/baselines/template-lexer/11.indent/01.script-block/07.object-dedent-further.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const props = {\n\"id\": \"some_id\"\n  };\n",
+    "text": "\n  const props = {\n\"id\": \"some_id\"\n  };\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 57,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "...props",
+    "text": "...props",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 81,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/11.indent/01.script-block/08.object-indent-further.svelte.json
+++ b/test/baselines/template-lexer/11.indent/01.script-block/08.object-indent-further.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const props = {\n      \"id\": \"some_id\"\n  };\n",
+    "text": "\n  const props = {\n      \"id\": \"some_id\"\n  };\n",
+    "offset": 8,
+    "lineBreaks": 4,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 63,
+    "lineBreaks": 2,
+    "line": 5,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_html_attribute_start",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "...props",
+    "text": "...props",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_attribute_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 22
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 87,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 23
+  }
+]

--- a/test/baselines/template-lexer/11.indent/01.script-block/09.array-dedent.svelte.json
+++ b/test/baselines/template-lexer/11.indent/01.script-block/09.array-dedent.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const titles = [\n  \"A Blog Post\",\n  \"Another Plog Post\"\n  ];\n",
+    "text": "\n  const titles = [\n  \"A Blog Post\",\n  \"Another Plog Post\"\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 81,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "post",
+    "text": "post",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 105,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "post",
+    "text": "post",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 11
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 121,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 129,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/11.indent/01.script-block/10.array-dedent-further.svelte.json
+++ b/test/baselines/template-lexer/11.indent/01.script-block/10.array-dedent-further.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const titles = [\n\"A Blog Post\",\n\"Another Plog Post\"\n  ];\n",
+    "text": "\n  const titles = [\n\"A Blog Post\",\n\"Another Plog Post\"\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 77,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "post",
+    "text": "post",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 101,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "post",
+    "text": "post",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 11
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 125,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/11.indent/01.script-block/11.array-indent-further.svelte.json
+++ b/test/baselines/template-lexer/11.indent/01.script-block/11.array-indent-further.svelte.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const titles = [\n      \"A Blog Post\",\n      \"Another Plog Post\"\n  ];\n",
+    "text": "\n  const titles = [\n      \"A Blog Post\",\n      \"Another Plog Post\"\n  ];\n",
+    "offset": 8,
+    "lineBreaks": 5,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 89,
+    "lineBreaks": 2,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "post",
+    "text": "post",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 113,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "post",
+    "text": "post",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 11
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 12
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 129,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 137,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/12.labels/01.dollar-sign/01.reactive-declaration.svelte.json
+++ b/test/baselines/template-lexer/12.labels/01.dollar-sign/01.reactive-declaration.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  export let value = 2;\n\n  const doubler = 2;\n\n  $: doubled = value * doubler;\n",
+    "text": "\n  export let value = 2;\n\n  const doubler = 2;\n\n  $: doubled = value * doubler;\n",
+    "offset": 8,
+    "lineBreaks": 6,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 97,
+    "lineBreaks": 2,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Doubled: ",
+    "text": "Doubled: ",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "doubled",
+    "text": "doubled",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 128,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/12.labels/01.dollar-sign/02.reactive-statement.svelte.json
+++ b/test/baselines/template-lexer/12.labels/01.dollar-sign/02.reactive-statement.svelte.json
@@ -1,0 +1,74 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable no-console ",
+    "text": " eslint-disable no-console ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 34,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  export let value = 2;\n\n  $: console.log(\"New value:\", value);\n",
+    "text": "\n  export let value = 2;\n\n  $: console.log(\"New value:\", value);\n",
+    "offset": 43,
+    "lineBreaks": 4,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/12.labels/01.dollar-sign/03.reactive-block.svelte.json
+++ b/test/baselines/template-lexer/12.labels/01.dollar-sign/03.reactive-block.svelte.json
@@ -1,0 +1,74 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable no-console, one-var ",
+    "text": " eslint-disable no-console, one-var ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 40,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 41
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 43,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 44
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  import {calculate} from \"./utils\";\n  export let value = 2;\n\n  let calculated = calculate(value);\n\n  $: {\n\n    console.log(\"New Value:\", value);\n    console.log(\"Old Caluclated:\", calculated);\n    calculated = calculate;\n    console.log(\"New Caluclated:\", calculated);\n\n  }\n",
+    "text": "\n  import {calculate} from \"./utils\";\n  export let value = 2;\n\n  let calculated = calculate(value);\n\n  $: {\n\n    console.log(\"New Value:\", value);\n    console.log(\"Old Caluclated:\", calculated);\n    calculated = calculate;\n    console.log(\"New Caluclated:\", calculated);\n\n  }\n",
+    "offset": 52,
+    "lineBreaks": 14,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 328,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 337,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/12.labels/01.dollar-sign/04.reactive-if-block.svelte.json
+++ b/test/baselines/template-lexer/12.labels/01.dollar-sign/04.reactive-if-block.svelte.json
@@ -1,0 +1,74 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable no-console ",
+    "text": " eslint-disable no-console ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 34,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  export let value = 2;\n\n  const max = 10;\n\n  $: if (value > max) {\n\n    console.log(\"Tha's a lot:\", value);\n\n  }\n",
+    "text": "\n  export let value = 2;\n\n  const max = 10;\n\n  $: if (value > max) {\n\n    console.log(\"Tha's a lot:\", value);\n\n  }\n",
+    "offset": 43,
+    "lineBreaks": 10,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 167,
+    "lineBreaks": 1,
+    "line": 12,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/12.labels/01.dollar-sign/05.reactive-misdeclaration.svelte.json
+++ b/test/baselines/template-lexer/12.labels/01.dollar-sign/05.reactive-misdeclaration.svelte.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  export let value = 2;\n\n  const doubler = 2;\n\n  $: {\n\n    doubled = value * doubler;\n\n  }\n",
+    "text": "\n  export let value = 2;\n\n  const doubler = 2;\n\n  $: {\n\n    doubled = value * doubler;\n\n  }\n",
+    "offset": 8,
+    "lineBreaks": 10,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 109,
+    "lineBreaks": 2,
+    "line": 11,
+    "col": 10
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 1
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 2
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Doubled: ",
+    "text": "Doubled: ",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 15
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 16
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "doubled",
+    "text": "doubled",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "div",
+    "text": "div",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 13,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 140,
+    "lineBreaks": 1,
+    "line": 13,
+    "col": 30
+  }
+]

--- a/test/baselines/template-lexer/12.labels/02.others/01.unwanted.svelte.json
+++ b/test/baselines/template-lexer/12.labels/02.others/01.unwanted.svelte.json
@@ -1,0 +1,74 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable no-console ",
+    "text": " eslint-disable no-console ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 31,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 32
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 34,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 35
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 35,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  label: console.log(\"Not reactive\");\n",
+    "text": "\n  label: console.log(\"Not reactive\");\n",
+    "offset": 43,
+    "lineBreaks": 2,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 91,
+    "lineBreaks": 1,
+    "line": 4,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/12.labels/02.others/02.unused.svelte.json
+++ b/test/baselines/template-lexer/12.labels/02.others/02.unused.svelte.json
@@ -1,0 +1,74 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable no-console, @jarrodldavis/svelte/no-labels ",
+    "text": " eslint-disable no-console, @jarrodldavis/svelte/no-labels ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 64
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 66,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 67
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  label: console.log(\"Not reactive\");\n",
+    "text": "\n  label: console.log(\"Not reactive\");\n",
+    "offset": 75,
+    "lineBreaks": 2,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 4,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 123,
+    "lineBreaks": 1,
+    "line": 4,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/12.labels/02.others/03.unnecessary.svelte.json
+++ b/test/baselines/template-lexer/12.labels/02.others/03.unnecessary.svelte.json
@@ -1,0 +1,74 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable @jarrodldavis/svelte/no-labels ",
+    "text": " eslint-disable @jarrodldavis/svelte/no-labels ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 52
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 54,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 55
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  export let values = [];\n\n  label:\n  for (const item of values) {\n\n    break label;\n\n  }\n",
+    "text": "\n  export let values = [];\n\n  label:\n  for (const item of values) {\n\n    break label;\n\n  }\n",
+    "offset": 63,
+    "lineBreaks": 9,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 154,
+    "lineBreaks": 0,
+    "line": 11,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 163,
+    "lineBreaks": 1,
+    "line": 11,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/12.labels/02.others/04.used.svelte.json
+++ b/test/baselines/template-lexer/12.labels/02.others/04.used.svelte.json
@@ -1,0 +1,74 @@
+[
+  {
+    "type": "_comment_start",
+    "value": "<!--",
+    "text": "<!--",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_comment_contents",
+    "value": " eslint-disable @jarrodldavis/svelte/no-labels ",
+    "text": " eslint-disable @jarrodldavis/svelte/no-labels ",
+    "offset": 4,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 5
+  },
+  {
+    "type": "_comment_end",
+    "value": "-->",
+    "text": "-->",
+    "offset": 51,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 52
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 54,
+    "lineBreaks": 1,
+    "line": 1,
+    "col": 55
+  },
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 2,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  export let values = [];\n\n  const max = 10;\n\n  label: {\n\n    if (values.length > max) {\n\n      break label;\n\n    }\n\n  }\n",
+    "text": "\n  export let values = [];\n\n  const max = 10;\n\n  label: {\n\n    if (values.length > max) {\n\n      break label;\n\n    }\n\n  }\n",
+    "offset": 63,
+    "lineBreaks": 14,
+    "line": 2,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 185,
+    "lineBreaks": 0,
+    "line": 16,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 194,
+    "lineBreaks": 1,
+    "line": 16,
+    "col": 10
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/01.if/01.empty-if.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/01.if/01.empty-if.svelte.json
@@ -1,0 +1,137 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 63,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/02.if-else/01.empty-if.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/02.if-else/01.empty-if.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 65,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 69,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Disabled",
+    "text": "Disabled",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 83,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 89,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/02.if-else/02.empty-else.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/02.if-else/02.empty-else.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 88,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/02.if-else/03.empty-if-empty-else.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/02.if-else/03.empty-if-empty-else.svelte.json
@@ -1,0 +1,182 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 65,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 71,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/03.if-else-if/01.empty-if.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/03.if-else-if/01.empty-if.svelte.json
@@ -1,0 +1,317 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "!enabled",
+    "text": "!enabled",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 77,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Disabled",
+    "text": "Disabled",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 95,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 101,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/03.if-else-if/02.empty-else-if.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/03.if-else-if/02.empty-else-if.svelte.json
@@ -1,0 +1,317 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "!enabled",
+    "text": "!enabled",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 100,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/03.if-else-if/03.empty-if-empty-else-if.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/03.if-else-if/03.empty-if-empty-else-if.svelte.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "!enabled",
+    "text": "!enabled",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 77,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 83,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/01.empty-if.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/01.empty-if.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "!enabled",
+    "text": "!enabled",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 77,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Disabled",
+    "text": "Disabled",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 95,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 103,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Something Else",
+    "text": "Something Else",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 127,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 133,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/02.empty-else-if.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/02.empty-else-if.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "!enabled",
+    "text": "!enabled",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Something Else",
+    "text": "Something Else",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 126,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 132,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/03.empty-else.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/03.empty-else.svelte.json
@@ -1,0 +1,452 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "!enabled",
+    "text": "!enabled",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Disabled",
+    "text": "Disabled",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 112,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 120,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 126,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/04.empty-else-if-empty-else.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/04.empty-else-if-empty-else.svelte.json
@@ -1,0 +1,362 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 62,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Enabled",
+    "text": "Enabled",
+    "offset": 63,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 13
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 72,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 74,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "!enabled",
+    "text": "!enabled",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 108,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/05.empty-if-empty-else-if.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/05.empty-if-empty-else-if.svelte.json
@@ -1,0 +1,362 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "!enabled",
+    "text": "!enabled",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 77,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 85,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Something Else",
+    "text": "Something Else",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 20
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 22
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 109,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 115,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/06.empty-if-empty-else.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/06.empty-if-empty-else.svelte.json
@@ -1,0 +1,362 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "!enabled",
+    "text": "!enabled",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 77,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Negative",
+    "text": "Negative",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 95,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 103,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 109,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/07.empty-if-empty-else-if-empty-else.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/01.if/04.if-else-if-else/07.empty-if-empty-else-if-empty-else.svelte.json
@@ -1,0 +1,272 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const enabled = true;\n",
+    "text": "\n  const enabled = true;\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 33,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 42,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 44,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "if_open",
+    "value": "#if",
+    "text": "#if",
+    "offset": 45,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_if_expression",
+    "value": " enabled",
+    "text": " enabled",
+    "offset": 48,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 5
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 56,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 13
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 57,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 57,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 14
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 58,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 59,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 64,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "else_if",
+    "value": "if",
+    "text": "if",
+    "offset": 65,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 10
+  },
+  {
+    "type": "_else_if_expression",
+    "value": "!enabled",
+    "text": "!enabled",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "_else_if_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 77,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 85,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "if_close",
+    "value": "/if",
+    "text": "/if",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 91,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 6
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/02.each/01.no-else/01.empty-each.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/02.each/01.no-else/01.empty-each.svelte.json
@@ -1,0 +1,200 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const titles = [\"A Blog Post\"];\n",
+    "text": "\n  const titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 52,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "post",
+    "text": "post",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 84,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/02.each/02.else/01.empty-each.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/02.each/02.else/01.empty-each.svelte.json
@@ -1,0 +1,335 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const titles = [\"A Blog Post\"];\n",
+    "text": "\n  const titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 52,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "post",
+    "text": "post",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 84,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "No Posts",
+    "text": "No Posts",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 16
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 110,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/02.each/02.else/02.empty-else.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/02.each/02.else/02.empty-else.svelte.json
@@ -1,0 +1,371 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const titles = [\"A Blog Post\"];\n",
+    "text": "\n  const titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 52,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "post",
+    "text": "post",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 79,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 80,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "post",
+    "text": "post",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 11
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 12
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 92,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 100,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 107,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 108,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/02.each/02.else/03.empty-each-empty-else.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/02.each/02.else/03.empty-each-empty-else.svelte.json
@@ -1,0 +1,245 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const titles = [\"A Blog Post\"];\n",
+    "text": "\n  const titles = [\"A Blog Post\"];\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 43,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 52,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 54,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "each_open",
+    "value": "#each",
+    "text": "#each",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 60,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 7
+  },
+  {
+    "type": "_each_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_each_expression",
+    "value": "titles ",
+    "text": "titles ",
+    "offset": 61,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "each_as",
+    "value": "as",
+    "text": "as",
+    "offset": 68,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 15
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 70,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_each_context_start",
+    "value": "",
+    "text": "",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_each_context",
+    "value": "post",
+    "text": "post",
+    "offset": 71,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 18
+  },
+  {
+    "type": "_each_context_end",
+    "value": "",
+    "text": "",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 75,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 76,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 76,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 23
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 77,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "else_open",
+    "value": ":else",
+    "text": ":else",
+    "offset": 78,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 84,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "each_close",
+    "value": "/each",
+    "text": "/each",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 91,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 92,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 92,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 8
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/01.empty-pending.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/01.empty-pending.svelte.json
@@ -1,0 +1,560 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 97,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 127,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 142,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 160,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 165,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 166,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 170,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 172,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 178,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 179,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 179,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/02.empty-then.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/02.empty-then.svelte.json
@@ -1,0 +1,515 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting...",
+    "text": "Waiting...",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 132,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 137,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 158,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 159,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 160,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 168,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 169,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 169,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/03.empty-catch.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/03.empty-catch.svelte.json
@@ -1,0 +1,515 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting...",
+    "text": "Waiting...",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 147,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 155,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 156,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 161,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 162,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 162,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 163,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 164,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 170,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 171,
+    "lineBreaks": 0,
+    "line": 10,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 171,
+    "lineBreaks": 1,
+    "line": 10,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/04.empty-then-empty-catch.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/04.empty-then-empty-catch.svelte.json
@@ -1,0 +1,380 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting...",
+    "text": "Waiting...",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 131,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 132,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 134,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 141,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/05.empty-pending-empty-then.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/05.empty-pending-empty-then.svelte.json
@@ -1,0 +1,425 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 97,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 112,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 130,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 140,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 149,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 149,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/06.empty-pending-empty-catch.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/06.empty-pending-empty-catch.svelte.json
@@ -1,0 +1,425 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 97,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 127,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 142,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 142,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 143,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 144,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 150,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 151,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 151,
+    "lineBreaks": 1,
+    "line": 9,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/07.empty-pending-empty-then-empty-catch.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/01.full-catch/07.empty-pending-empty-then-empty-catch.svelte.json
@@ -1,0 +1,290 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 97,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 112,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 121,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 121,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/02.full-no-catch/01.empty-pending.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/02.full-no-catch/01.empty-pending.svelte.json
@@ -1,0 +1,362 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 97,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 127,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 128,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 129,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 136,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/02.full-no-catch/02.empty-then.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/02.full-no-catch/02.empty-then.svelte.json
@@ -1,0 +1,317 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 85,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Waiting...",
+    "text": "Waiting...",
+    "offset": 88,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 16
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 101,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 102,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 20
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 104,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 116,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 117,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 126,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/02.full-no-catch/03.empty-pending-empty-then.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/02.full-no-catch/03.empty-pending-empty-then.svelte.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise",
+    "text": "promise",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_full_end",
+    "value": "",
+    "text": "",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 81,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 16
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 82,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 83,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "await_full_then",
+    "value": ":then",
+    "text": ":then",
+    "offset": 84,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 89,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 7
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 90,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 97,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 105,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 106,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 106,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/03.compact-catch/01.empty-then.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/03.compact-catch/01.empty-then.svelte.json
@@ -1,0 +1,389 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise ",
+    "text": "promise ",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "await_compact_then",
+    "value": "then",
+    "text": "then",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_await_then_compact_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 109,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 114,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got error: ",
+    "text": "Got error: ",
+    "offset": 115,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 17
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "error",
+    "text": "error",
+    "offset": 127,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 18
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 23
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 24
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 135,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 26
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 136,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 27
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 137,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 28
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 145,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 146,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 146,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/03.compact-catch/02.empty-catch.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/03.compact-catch/02.empty-catch.svelte.json
@@ -1,0 +1,389 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise ",
+    "text": "promise ",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "await_compact_then",
+    "value": "then",
+    "text": "then",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_await_then_compact_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n  ",
+    "text": "\n  ",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "html_open_start",
+    "value": "<",
+    "text": "<",
+    "offset": 97,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 3
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 98,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 4
+  },
+  {
+    "type": "_html_attributes_end",
+    "value": "",
+    "text": "",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "html_open_end",
+    "value": ">",
+    "text": ">",
+    "offset": 99,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 5
+  },
+  {
+    "type": "_body",
+    "value": "Got result: ",
+    "text": "Got result: ",
+    "offset": 100,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 6
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 112,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 18
+  },
+  {
+    "type": "_simple_tag_start",
+    "value": "",
+    "text": "",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "_simple_mustache_expression",
+    "value": "result",
+    "text": "result",
+    "offset": 113,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 19
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 119,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 25
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 120,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 26
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
+    "offset": 122,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 28
+  },
+  {
+    "type": "_html_close_end",
+    "value": "",
+    "text": "",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "html_close_end",
+    "value": ">",
+    "text": ">",
+    "offset": 123,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 124,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 30
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 126,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 132,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 133,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 138,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 139,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 139,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 140,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 141,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 147,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 148,
+    "lineBreaks": 0,
+    "line": 8,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 148,
+    "lineBreaks": 1,
+    "line": 8,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/03.compact-catch/03.empty-then-empty-catch.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/03.compact-catch/03.empty-then-empty-catch.svelte.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise ",
+    "text": "promise ",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "await_compact_then",
+    "value": "then",
+    "text": "then",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_await_then_compact_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "await_catch",
+    "value": ":catch",
+    "text": ":catch",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "await_catch_identifier",
+    "value": "error",
+    "text": "error",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 108,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 14
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 109,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 109,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 15
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 110,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 111,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 117,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 118,
+    "lineBreaks": 0,
+    "line": 7,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 118,
+    "lineBreaks": 1,
+    "line": 7,
+    "col": 9
+  }
+]

--- a/test/baselines/template-lexer/13.empty-blocks/03.await/04.compact-no-catch/01.empty-then.svelte.json
+++ b/test/baselines/template-lexer/13.empty-blocks/03.await/04.compact-no-catch/01.empty-then.svelte.json
@@ -1,0 +1,191 @@
+[
+  {
+    "type": "_script_start_tag",
+    "value": "<script>",
+    "text": "<script>",
+    "offset": 0,
+    "lineBreaks": 0,
+    "line": 1,
+    "col": 1
+  },
+  {
+    "type": "_script_body",
+    "value": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "text": "\n  const promise = Promise.resolve(\"a value\");\n",
+    "offset": 8,
+    "lineBreaks": 2,
+    "line": 1,
+    "col": 9
+  },
+  {
+    "type": "_end_script_tag",
+    "value": "</script>",
+    "text": "</script>",
+    "offset": 55,
+    "lineBreaks": 0,
+    "line": 3,
+    "col": 1
+  },
+  {
+    "type": "_body",
+    "value": "\n\n",
+    "text": "\n\n",
+    "offset": 64,
+    "lineBreaks": 2,
+    "line": 3,
+    "col": 10
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 66,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 1
+  },
+  {
+    "type": "await_open",
+    "value": "#await",
+    "text": "#await",
+    "offset": 67,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 2
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 73,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 8
+  },
+  {
+    "type": "_await_expression_start",
+    "value": "",
+    "text": "",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "_await_promise_expression",
+    "value": "promise ",
+    "text": "promise ",
+    "offset": 74,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 9
+  },
+  {
+    "type": "await_compact_then",
+    "value": "then",
+    "text": "then",
+    "offset": 82,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 17
+  },
+  {
+    "type": "_whitespace",
+    "value": " ",
+    "text": " ",
+    "offset": 86,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 21
+  },
+  {
+    "type": "_await_then_compact_start",
+    "value": "",
+    "text": "",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "await_then_identifier",
+    "value": "result",
+    "text": "result",
+    "offset": 87,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 22
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 93,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 28
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 94,
+    "lineBreaks": 0,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 94,
+    "lineBreaks": 1,
+    "line": 5,
+    "col": 29
+  },
+  {
+    "type": "mustache_start",
+    "value": "{",
+    "text": "{",
+    "offset": 95,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 1
+  },
+  {
+    "type": "await_close",
+    "value": "/await",
+    "text": "/await",
+    "offset": 96,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 2
+  },
+  {
+    "type": "mustache_end",
+    "value": "}",
+    "text": "}",
+    "offset": 102,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 8
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 103,
+    "lineBreaks": 0,
+    "line": 6,
+    "col": 9
+  },
+  {
+    "type": "_body",
+    "value": "\n",
+    "text": "\n",
+    "offset": 103,
+    "lineBreaks": 1,
+    "line": 6,
+    "col": 9
+  }
+]

--- a/test/template-lexer.spec.js
+++ b/test/template-lexer.spec.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const { create_root_suite } = require("./helpers/create-baseline-suite");
+const {
+  template_lexer
+} = require("../lib/parser/converter/helpers/template-lexer");
+
+create_root_suite("template-lexer", template =>
+  Array.from(template_lexer.reset(template))
+);


### PR DESCRIPTION
- [x] Define a baseline suite for the template lexer
- [x] Establish and accept baselines for the template lexer
    - [x] templates with angle bracket tags
    - [x] templates with at-tags
    - [x] templates with if blocks
    - [x] templates with each blocks
    - [x] templates with await blocks
    - [x] templates with directives
    - [x] templates with implicit variables and references
    - [x] templates with references to undefined variables
    - [x] templates with declarations of unused variables
    - [x] templates with ESLint comment directives
    - [x] templates with script blocks that violate the `indent` rule override
    - [x] templates with script blocks with labels (`no-labels`/`no-unused-labels` rule overrides)
    - [x] templates with empty if, each, and await blocks