### PR TITLE
Prepare testing for converter baselines

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,5 +1,5 @@
 {
   "all": true,
   "include": ["index.js", "individual-warnings.js", "lib/**/*.js"],
-  "reporter": ["text"]
+  "reporter": ["text", "html"]
 }

--- a/lib/parser/converter/index.js
+++ b/lib/parser/converter/index.js
@@ -9,7 +9,7 @@ function convert(code, options, ast) {
   new Converter(code, options).visit(ast_clone);
 
   // re-normalize to plain objects
-  return JSON.parse(JSON.stringify(ast_clone));
+  return JSON.parse(JSON.stringify(ast_clone.html));
 }
 
 module.exports = { convert };

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -29,24 +29,13 @@ function compile_template(code) {
 function parse(code, options) {
   const result = compile_template(code);
 
-  const {
-    html: program,
-    css,
-    instance: js_instance,
-    module: js_module
-  } = convert(code, options, result.ast);
+  const program = convert(code, options, result.ast);
 
   const scopeManager = analyze(program, options, result.vars);
 
   return {
     ast: program,
-    services: {
-      warnings: result.warnings,
-      vars: result.vars,
-      css,
-      js_instance,
-      js_module
-    },
+    services: { warnings: result.warnings, vars: result.vars },
     visitorKeys: ALL_SVELTE_KEYS,
     scopeManager
   };

--- a/test/baselines/template-lexer/09.unused/10.each/02.object-context/02.index.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/02.object-context/02.index.svelte.json
@@ -253,8 +253,8 @@
   },
   {
     "type": "_simple_mustache_expression",
-    "value": "title",
-    "text": "title",
+    "value": "id",
+    "text": "id",
     "offset": 122,
     "lineBreaks": 0,
     "line": 9,
@@ -264,70 +264,70 @@
     "type": "mustache_end",
     "value": "}",
     "text": "}",
+    "offset": 124,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 125,
+    "lineBreaks": 0,
+    "line": 9,
+    "col": 10
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
     "offset": 127,
     "lineBreaks": 0,
     "line": 9,
     "col": 12
   },
   {
-    "type": "_mustache_end",
-    "value": "",
-    "text": "",
-    "offset": 128,
-    "lineBreaks": 0,
-    "line": 9,
-    "col": 13
-  },
-  {
-    "type": "html_close_start",
-    "value": "</",
-    "text": "</",
-    "offset": 128,
-    "lineBreaks": 0,
-    "line": 9,
-    "col": 13
-  },
-  {
-    "type": "html_tag_name",
-    "value": "p",
-    "text": "p",
-    "offset": 130,
-    "lineBreaks": 0,
-    "line": 9,
-    "col": 15
-  },
-  {
     "type": "_html_close_end",
     "value": "",
     "text": "",
-    "offset": 131,
+    "offset": 128,
     "lineBreaks": 0,
     "line": 9,
-    "col": 16
+    "col": 13
   },
   {
     "type": "html_close_end",
     "value": ">",
     "text": ">",
-    "offset": 131,
+    "offset": 128,
     "lineBreaks": 0,
     "line": 9,
-    "col": 16
+    "col": 13
   },
   {
     "type": "_body",
     "value": "\n",
     "text": "\n",
-    "offset": 132,
+    "offset": 129,
     "lineBreaks": 1,
     "line": 9,
-    "col": 17
+    "col": 14
   },
   {
     "type": "mustache_start",
     "value": "{",
     "text": "{",
-    "offset": 133,
+    "offset": 130,
     "lineBreaks": 0,
     "line": 10,
     "col": 1
@@ -336,7 +336,7 @@
     "type": "each_close",
     "value": "/each",
     "text": "/each",
-    "offset": 134,
+    "offset": 131,
     "lineBreaks": 0,
     "line": 10,
     "col": 2
@@ -345,7 +345,7 @@
     "type": "mustache_end",
     "value": "}",
     "text": "}",
-    "offset": 139,
+    "offset": 136,
     "lineBreaks": 0,
     "line": 10,
     "col": 7
@@ -354,7 +354,7 @@
     "type": "_mustache_end",
     "value": "",
     "text": "",
-    "offset": 140,
+    "offset": 137,
     "lineBreaks": 0,
     "line": 10,
     "col": 8
@@ -363,7 +363,7 @@
     "type": "_body",
     "value": "\n",
     "text": "\n",
-    "offset": 140,
+    "offset": 137,
     "lineBreaks": 1,
     "line": 10,
     "col": 8

--- a/test/baselines/template-lexer/09.unused/10.each/03.array-context/02.index.svelte.json
+++ b/test/baselines/template-lexer/09.unused/10.each/03.array-context/02.index.svelte.json
@@ -253,8 +253,8 @@
   },
   {
     "type": "_simple_mustache_expression",
-    "value": "title",
-    "text": "title",
+    "value": "id",
+    "text": "id",
     "offset": 150,
     "lineBreaks": 0,
     "line": 12,
@@ -264,70 +264,70 @@
     "type": "mustache_end",
     "value": "}",
     "text": "}",
+    "offset": 152,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 9
+  },
+  {
+    "type": "_mustache_end",
+    "value": "",
+    "text": "",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 10
+  },
+  {
+    "type": "html_close_start",
+    "value": "</",
+    "text": "</",
+    "offset": 153,
+    "lineBreaks": 0,
+    "line": 12,
+    "col": 10
+  },
+  {
+    "type": "html_tag_name",
+    "value": "p",
+    "text": "p",
     "offset": 155,
     "lineBreaks": 0,
     "line": 12,
     "col": 12
   },
   {
-    "type": "_mustache_end",
-    "value": "",
-    "text": "",
-    "offset": 156,
-    "lineBreaks": 0,
-    "line": 12,
-    "col": 13
-  },
-  {
-    "type": "html_close_start",
-    "value": "</",
-    "text": "</",
-    "offset": 156,
-    "lineBreaks": 0,
-    "line": 12,
-    "col": 13
-  },
-  {
-    "type": "html_tag_name",
-    "value": "p",
-    "text": "p",
-    "offset": 158,
-    "lineBreaks": 0,
-    "line": 12,
-    "col": 15
-  },
-  {
     "type": "_html_close_end",
     "value": "",
     "text": "",
-    "offset": 159,
+    "offset": 156,
     "lineBreaks": 0,
     "line": 12,
-    "col": 16
+    "col": 13
   },
   {
     "type": "html_close_end",
     "value": ">",
     "text": ">",
-    "offset": 159,
+    "offset": 156,
     "lineBreaks": 0,
     "line": 12,
-    "col": 16
+    "col": 13
   },
   {
     "type": "_body",
     "value": "\n",
     "text": "\n",
-    "offset": 160,
+    "offset": 157,
     "lineBreaks": 1,
     "line": 12,
-    "col": 17
+    "col": 14
   },
   {
     "type": "mustache_start",
     "value": "{",
     "text": "{",
-    "offset": 161,
+    "offset": 158,
     "lineBreaks": 0,
     "line": 13,
     "col": 1
@@ -336,7 +336,7 @@
     "type": "each_close",
     "value": "/each",
     "text": "/each",
-    "offset": 162,
+    "offset": 159,
     "lineBreaks": 0,
     "line": 13,
     "col": 2
@@ -345,7 +345,7 @@
     "type": "mustache_end",
     "value": "}",
     "text": "}",
-    "offset": 167,
+    "offset": 164,
     "lineBreaks": 0,
     "line": 13,
     "col": 7
@@ -354,7 +354,7 @@
     "type": "_mustache_end",
     "value": "",
     "text": "",
-    "offset": 168,
+    "offset": 165,
     "lineBreaks": 0,
     "line": 13,
     "col": 8
@@ -363,7 +363,7 @@
     "type": "_body",
     "value": "\n",
     "text": "\n",
-    "offset": 168,
+    "offset": 165,
     "lineBreaks": 1,
     "line": 13,
     "col": 8

--- a/test/helpers/create-baseline-suite.js
+++ b/test/helpers/create-baseline-suite.js
@@ -12,6 +12,7 @@ const {
   load_baselines,
   NAME,
   IS_DIRECTORY,
+  TEMPLATE_PATH,
   TEMPLATE_CONTENTS,
   BASELINE_PATH,
   BASELINE_CONTENTS
@@ -25,7 +26,8 @@ const BASELINE_ROOT = path.join(__dirname, "../", "baselines/");
 class BaselineSuite {
   constructor(name, get_result) {
     this.name = name;
-    this.get_result = entry => JSON.parse(JSON.stringify(get_result(entry)));
+    this.get_result = (...args) =>
+      JSON.parse(JSON.stringify(get_result(...args)));
     this.directory = path.join(BASELINE_ROOT, name, "/");
     this.to_add = [];
     this.to_update = [];
@@ -79,7 +81,10 @@ class BaselineSuite {
     expect(entry, "to have a template");
     this.to_delete.pop();
 
-    const result = this.get_result(entry[TEMPLATE_CONTENTS]);
+    const result = this.get_result(
+      entry[TEMPLATE_CONTENTS],
+      entry[TEMPLATE_PATH]
+    );
 
     this.to_add.push({ path: baseline_path, contents: result });
     expect(entry, "to have a baseline");

--- a/test/templates/09.unused/10.each/02.object-context/02.index.svelte
+++ b/test/templates/09.unused/10.each/02.object-context/02.index.svelte
@@ -6,5 +6,5 @@
 </script>
 
 {#each posts as {id}, index}
-  <p>{title}</p>
+  <p>{id}</p>
 {/each}

--- a/test/templates/09.unused/10.each/03.array-context/02.index.svelte
+++ b/test/templates/09.unused/10.each/03.array-context/02.index.svelte
@@ -9,5 +9,5 @@
 </script>
 
 {#each posts as [id], index}
-  <p>{title}</p>
+  <p>{id}</p>
 {/each}


### PR DESCRIPTION
Fix various stuff in preparation for establishing converter baselines

- [x] Remove the JavaScript and CSS ASTs from the return values of the converter and parser since they aren't used
- [x] Fix test templates
- [x] Add HTML reporting for code coverage
- [x] Call baseline generators with template file path